### PR TITLE
Refactor: Merge two import statements from types/index.ts in compiler.ts [XS]

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -6,11 +6,17 @@ import type {
   SkittlesConfig,
   SkittlesContract,
   BuildArtifact,
+  SkittlesParameter,
+  SkittlesFunction,
+  SkittlesConstructor,
+  SkittlesContractInterface,
+  Expression,
+  Statement,
+  StateMutability,
 } from "../types/index.ts";
 import { findTypeScriptFiles, readFile, writeFile } from "../utils/file.ts";
 import { logInfo, logSuccess, logError, logWarning } from "../utils/console.ts";
 import { parse, collectTypes, collectFunctions, collectClassNames } from "./parser.ts";
-import type { SkittlesParameter, SkittlesFunction, SkittlesConstructor, SkittlesContractInterface, Expression, Statement, StateMutability } from "../types/index.ts";
 import { generateSolidity, generateSolidityFile, buildSourceMap } from "./codegen.ts";
 import { analyzeFunction } from "./analysis.ts";
 import { getStdlibClassNames, resolveStdlibFiles, getStdlibContractsDir } from "../stdlib/resolver.ts";


### PR DESCRIPTION
Closes #278

## Problem

`src/compiler/compiler.ts` has two separate import statements from the same module on consecutive lines:

```typescript
import type {
  SkittlesConfig,
  SkittlesContract,
  BuildArtifact,
} from "../types/index.ts";
// ... other imports ...
import type { SkittlesParameter, SkittlesFunction, SkittlesConstructor, SkittlesContractInterface, Expression, Statement, StateMutability } from "../types/index.ts";
```

Lines 5–9 and line 13 both import from `../types/index.ts`.

## Suggested Fix

Merge into a single import statement:

```typescript
import type {
  SkittlesConfig,
  SkittlesContract,
  BuildArtifact,
  SkittlesParameter,
  SkittlesFunction,
  SkittlesConstructor,
  SkittlesContractInterface,
  Expression,
  Statement,
  StateMutability,
} from "../types/index.ts";
```