### PR TITLE
Cleanup: webapp fetch error for npm version is silently swallowed [XS]

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -14,7 +14,7 @@ function useNpmVersion() {
       .then((data) => {
         if (data.version) setVersion(data.version);
       })
-      .catch(() => { });
+      .catch((err) => console.warn("Failed to fetch npm version:", err));
   }, []);
   return version;
 }


### PR DESCRIPTION
Closes #277

## Problem

In `webapp/src/App.tsx`, the `useNpmVersion` hook fetches the latest npm version but has an empty catch:

```typescript
useEffect(() => {
  fetch("https://registry.npmjs.org/skittles/latest")
    .then(r => r.json())
    .then(data => setVersion(data.version))
    .catch(() => {}); // error silently swallowed
}, []);
```

If the fetch fails (network error, CORS issue, API change), the version will remain as the fallback, which is fine functionally. But the completely empty catch makes debugging harder if the feature breaks.

## Suggested Fix

At minimum, log the error to the console:

```typescript
.catch(err => console.warn("Failed to fetch npm version:", err));
```

This preserves the graceful degradation while making issues discoverable during development.