### PR TITLE
Cleanup: analysis.ts walkNestedBlocks has redundant while/do-while cases [XS]

### DIFF
--- a/src/compiler/analysis.ts
+++ b/src/compiler/analysis.ts
@@ -75,8 +75,6 @@ function walkNestedBlocks(
       visitor(stmt.body);
       break;
     case "while":
-      visitor(stmt.body);
-      break;
     case "do-while":
       visitor(stmt.body);
       break;
@@ -168,9 +166,6 @@ function walkAllStatements(
         walkAllStatements(stmt.body, declared, used);
         break;
       case "while":
-        collectUsedIdentifiers(stmt.condition, used);
-        walkAllStatements(stmt.body, declared, used);
-        break;
       case "do-while":
         collectUsedIdentifiers(stmt.condition, used);
         walkAllStatements(stmt.body, declared, used);

--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -150,7 +150,6 @@ function renameInStatement(stmt: Statement, renames: Map<string, string>): State
       return { ...stmt, initializer: init, condition: stmt.condition ? renameInExpression(stmt.condition, renames) : undefined, incrementor: stmt.incrementor ? renameInExpression(stmt.incrementor, renames) : undefined, body: renameInStatements(stmt.body, renames) };
     }
     case "while":
-      return { ...stmt, condition: renameInExpression(stmt.condition, renames), body: renameInStatements(stmt.body, renames) };
     case "do-while":
       return { ...stmt, condition: renameInExpression(stmt.condition, renames), body: renameInStatements(stmt.body, renames) };
     case "emit":

--- a/src/compiler/mutability.ts
+++ b/src/compiler/mutability.ts
@@ -361,7 +361,6 @@ export function rewriteInterfacePropertyGetters(
         };
       }
       case "while":
-        return { ...stmt, condition: transformExpr(stmt.condition, false), body: stmt.body.map(transformStmt) };
       case "do-while":
         return { ...stmt, condition: transformExpr(stmt.condition, false), body: stmt.body.map(transformStmt) };
       case "revert":

--- a/src/compiler/parser-utils.ts
+++ b/src/compiler/parser-utils.ts
@@ -277,7 +277,7 @@ export function collectBareIdentifiersFromStmts(stmts: Statement[]): Set<string>
         walkStmts(s.body);
         break;
       }
-      case "while": walkExpr(s.condition); walkStmts(s.body); break;
+      case "while":
       case "do-while": walkExpr(s.condition); walkStmts(s.body); break;
       case "emit": s.args.forEach(walkExpr); break;
       case "revert": if (s.message) walkExpr(s.message); if (s.customErrorArgs) s.customErrorArgs.forEach(walkExpr); break;


### PR DESCRIPTION
Closes #274

## Problem

In `src/compiler/analysis.ts`, the `walkNestedBlocks` function (lines 65–93) has two separate cases that do the same thing:

```typescript
case "while":
  visitor(stmt.body);
  break;
case "do-while":
  visitor(stmt.body);
  break;
```

These can be combined using fall-through:

```typescript
case "while":
case "do-while":
  visitor(stmt.body);
  break;
```

This is a minor cleanup, but it's a pattern that appears in several switch statements across the codebase (analysis.ts, codegen.ts, parser.ts) where `while` and `do-while` cases are separated despite identical handling.

## Suggested Fix

Combine the cases wherever the handling is identical.