### PR TITLE
Cleanup: Use SkittlesTypeKind enum instead of string casts in parser.ts [S]

### DIFF
--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -1,17 +1,17 @@
 import ts from "typescript";
-import type {
-  SkittlesContract,
-  SkittlesVariable,
-  SkittlesFunction,
-  SkittlesConstructor,
-  SkittlesEvent,
-  SkittlesParameter,
-  SkittlesType,
+import {
   SkittlesTypeKind,
-  SkittlesContractInterface,
-  SkittlesInterfaceFunction,
-  Statement,
-  Expression,
+  type SkittlesContract,
+  type SkittlesVariable,
+  type SkittlesFunction,
+  type SkittlesConstructor,
+  type SkittlesEvent,
+  type SkittlesParameter,
+  type SkittlesType,
+  type SkittlesContractInterface,
+  type SkittlesInterfaceFunction,
+  type Statement,
+  type Expression,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import {
@@ -137,7 +137,7 @@ export function parseInterfaceAsContractInterface(
       const propName = member.name.text;
       const returnType: SkittlesType = member.type
         ? parseType(member.type)
-        : { kind: "uint256" as SkittlesTypeKind };
+        : { kind: SkittlesTypeKind.Uint256 };
       functions.push({ name: propName, parameters: [], returnType, stateMutability: "view" });
     }
 
@@ -238,7 +238,7 @@ export function parseClass(
       member.name && ts.isIdentifier(member.name) ? member.name.text : "unknown";
     const type: SkittlesType = member.type
       ? parseType(member.type)
-      : { kind: "uint256" as SkittlesTypeKind };
+      : { kind: SkittlesTypeKind.Uint256 };
     varTypes.set(name, type);
   }
   // Snapshot the state-variable-only map before any initializers/locals/params are parsed.
@@ -393,8 +393,8 @@ export function parseClass(
   const usedEnumNames = new Set<string>();
   const collectTypeRef = (type: SkittlesType | null | undefined) => {
     if (!type) return;
-    if (type.kind === ("struct" as SkittlesTypeKind) && type.structName) usedStructNames.add(type.structName);
-    if (type.kind === ("enum" as SkittlesTypeKind) && type.structName) usedEnumNames.add(type.structName);
+    if (type.kind === (SkittlesTypeKind.Struct) && type.structName) usedStructNames.add(type.structName);
+    if (type.kind === (SkittlesTypeKind.Enum) && type.structName) usedEnumNames.add(type.structName);
     if (type.keyType) collectTypeRef(type.keyType);
     if (type.valueType) collectTypeRef(type.valueType);
     if (type.tupleTypes) for (const t of type.tupleTypes) collectTypeRef(t);
@@ -642,7 +642,7 @@ export function tryParseEvent(
 
       const paramType: SkittlesType = typeNode
         ? parseType(typeNode)
-        : { kind: "uint256" as SkittlesTypeKind };
+        : { kind: SkittlesTypeKind.Uint256 };
       parameters.push({ name: paramName, type: paramType, indexed });
     }
   }
@@ -686,7 +686,7 @@ export function tryParseError(
       const paramName = member.name.text;
       const paramType: SkittlesType = member.type
         ? parseType(member.type)
-        : { kind: "uint256" as SkittlesTypeKind };
+        : { kind: SkittlesTypeKind.Uint256 };
       parameters.push({ name: paramName, type: paramType });
     }
   }
@@ -702,7 +702,7 @@ export function parseProperty(node: ts.PropertyDeclaration): SkittlesVariable {
 
   const type: SkittlesType = node.type
     ? parseType(node.type)
-    : { kind: "uint256" as SkittlesTypeKind };
+    : { kind: SkittlesTypeKind.Uint256 };
 
   const visibility = getVisibility(node.modifiers);
   const isStatic = hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword);
@@ -860,7 +860,7 @@ export function buildOverloadForwardingBody(
     args,
   };
 
-  if (returnType && returnType.kind !== ("void" as SkittlesTypeKind)) {
+  if (returnType && returnType.kind !== (SkittlesTypeKind.Void)) {
     return [{ kind: "return", value: callExpr }];
   } else {
     return [{ kind: "expression", expression: callExpr }];
@@ -869,16 +869,16 @@ export function buildOverloadForwardingBody(
 
 export function getDefaultValueForType(type: SkittlesType): Expression {
   switch (type.kind) {
-    case "uint256" as SkittlesTypeKind:
-    case "int256" as SkittlesTypeKind:
-    case "bytes32" as SkittlesTypeKind:
+    case SkittlesTypeKind.Uint256:
+    case SkittlesTypeKind.Int256:
+    case SkittlesTypeKind.Bytes32:
       return { kind: "number-literal", value: "0" };
-    case "bool" as SkittlesTypeKind:
+    case SkittlesTypeKind.Bool:
       return { kind: "boolean-literal", value: false };
-    case "string" as SkittlesTypeKind:
-    case "bytes" as SkittlesTypeKind:
+    case SkittlesTypeKind.String:
+    case SkittlesTypeKind.Bytes:
       return { kind: "string-literal", value: "" };
-    case "address" as SkittlesTypeKind:
+    case SkittlesTypeKind.Address:
       return {
         kind: "call",
         callee: { kind: "identifier", name: "address" },
@@ -1004,7 +1004,7 @@ export function parseParameter(node: ts.ParameterDeclaration): SkittlesParameter
   validateReservedName("Parameter name", name);
   const type: SkittlesType = node.type
     ? parseType(node.type)
-    : { kind: "uint256" as SkittlesTypeKind };
+    : { kind: SkittlesTypeKind.Uint256 };
   const param: SkittlesParameter = { name, type };
   if (node.initializer) {
     param.defaultValue = parseExpression(node.initializer);

--- a/src/compiler/expression-parser.ts
+++ b/src/compiler/expression-parser.ts
@@ -1,11 +1,11 @@
 import ts from "typescript";
-import type {
-  SkittlesType,
+import {
   SkittlesTypeKind,
-  SkittlesFunction,
-  SkittlesParameter,
-  Statement,
-  Expression,
+  type SkittlesType,
+  type SkittlesFunction,
+  type SkittlesParameter,
+  type Statement,
+  type Expression,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import {
@@ -266,7 +266,7 @@ export function parseExpression(node: ts.Expression): Expression {
       const receiverExpr = parseExpression(node.expression.expression);
       const typeSuffix = getArrayHelperSuffix(elementType);
 
-      const NON_COMPARABLE_KINDS = new Set(["struct", "array", "tuple", "mapping"] as SkittlesTypeKind[]);
+      const NON_COMPARABLE_KINDS = new Set([SkittlesTypeKind.Struct, SkittlesTypeKind.Array, SkittlesTypeKind.Tuple, SkittlesTypeKind.Mapping]);
       const isNonComparable = elementType != null && NON_COMPARABLE_KINDS.has(elementType.kind);
 
       // includes(value) → _arrIncludes_T(arr, value)
@@ -340,7 +340,7 @@ export function parseExpression(node: ts.Expression): Expression {
         const otherArg = node.arguments[0];
         if (ts.isPropertyAccessExpression(otherArg) && otherArg.expression.kind === ts.SyntaxKind.ThisKeyword) {
           const otherType = ctx.currentVarTypes.get(otherArg.name.text);
-          if (otherType?.kind === ("array" as SkittlesTypeKind)) {
+          if (otherType?.kind === (SkittlesTypeKind.Array)) {
             throw new Error(
               "Array .concat() cannot accept a storage array directly (e.g., this.a.concat(this.b)). " +
               "Use .slice() to copy to memory first: this.a.concat(this.b.slice(0, this.b.length))."
@@ -367,7 +367,7 @@ export function parseExpression(node: ts.Expression): Expression {
           throw new Error(`Array .${methodName}() accepts at most ${maxArity} argument(s), but ${node.arguments.length} were provided.`);
         }
         const sortParamType =
-          methodName === "sort" && elementType?.kind === ("uint256" as SkittlesTypeKind)
+          methodName === "sort" && elementType?.kind === (SkittlesTypeKind.Uint256)
             ? INT256_TYPE
             : elementType;
         const callbackParamTypes = methodName === "reduce"
@@ -710,7 +710,7 @@ export function parseExpression(node: ts.Expression): Expression {
         if (ts.isPropertyAccessExpression(e) && e.expression.kind === ts.SyntaxKind.ThisKeyword) {
           const name = e.name.text;
           const type = ctx.currentVarTypes.get(name);
-          if (type?.kind === ("array" as SkittlesTypeKind)) {
+          if (type?.kind === (SkittlesTypeKind.Array)) {
             // Storage array: wrap in slice to copy to memory
             ctx.neededArrayHelpers.add(`slice_${typeSuffix}`);
             const parsed = parseExpression(e);
@@ -802,7 +802,7 @@ export function parseExpression(node: ts.Expression): Expression {
           type = inferType(expr, combinedTypes);
         }
       }
-      const isUint256 = type !== undefined && type.kind === ("uint256" as SkittlesTypeKind);
+      const isUint256 = type !== undefined && type.kind === (SkittlesTypeKind.Uint256);
       if (isUint256) {
         parts.push({
           kind: "call",
@@ -840,7 +840,7 @@ function isArrayLikeReceiver(node: ts.Expression): boolean {
   if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
     const name = node.name.text;
     const type = ctx.currentVarTypes.get(name);
-    return type?.kind === ("array" as SkittlesTypeKind);
+    return type?.kind === (SkittlesTypeKind.Array);
   }
   return false;
 }
@@ -849,7 +849,7 @@ function resolveArrayElementType(node: ts.Expression): SkittlesType | undefined 
   if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
     const name = node.name.text;
     const type = ctx.currentVarTypes.get(name);
-    if (type?.kind === ("array" as SkittlesTypeKind)) {
+    if (type?.kind === (SkittlesTypeKind.Array)) {
       return type.valueType;
     }
   }
@@ -861,12 +861,12 @@ function resolveSpreadElementType(node: ts.Expression): SkittlesType | undefined
   if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
     const name = node.name.text;
     const type = ctx.currentVarTypes.get(name);
-    if (type?.kind === ("array" as SkittlesTypeKind)) return type.valueType;
+    if (type?.kind === (SkittlesTypeKind.Array)) return type.valueType;
   }
   // function parameter case
   if (ts.isIdentifier(node)) {
     const type = ctx.currentParamTypes.get(node.text);
-    if (type?.kind === ("array" as SkittlesTypeKind)) return type.valueType;
+    if (type?.kind === (SkittlesTypeKind.Array)) return type.valueType;
   }
   return undefined;
 }
@@ -898,13 +898,13 @@ function parseArrowCallback(
   }
   if (paramTypes?.first) {
     callbackVarTypes.set(paramName, paramTypes.first);
-    if (paramTypes.first.kind === ("string" as SkittlesTypeKind)) {
+    if (paramTypes.first.kind === (SkittlesTypeKind.String)) {
       callbackStringNames.add(paramName);
     }
   }
   if (paramTypes?.second && secondParamName) {
     callbackVarTypes.set(secondParamName, paramTypes.second);
-    if (paramTypes.second.kind === ("string" as SkittlesTypeKind)) {
+    if (paramTypes.second.kind === (SkittlesTypeKind.String)) {
       callbackStringNames.add(secondParamName);
     }
   }
@@ -938,7 +938,7 @@ function generateFilterHelper(
 ): SkittlesFunction {
   const helperName = `_filter_${ctx.arrayMethodCounter++}`;
   const elemType = elementType ?? UINT256_TYPE;
-  const arrType: SkittlesType = { kind: "array" as SkittlesTypeKind, valueType: elemType };
+  const arrType: SkittlesType = { kind: SkittlesTypeKind.Array, valueType: elemType };
   const elemTypeName = typeToSolidityName(elemType);
   const body: Statement[] = [
     mkVarDecl("__sk_count", UINT256_TYPE, mkNum("0")),
@@ -970,7 +970,7 @@ function generateMapHelper(
   const helperName = `_map_${ctx.arrayMethodCounter++}`;
   const elemType = elementType ?? UINT256_TYPE;
   const resultElemType = resultElementType ?? UINT256_TYPE;
-  const arrType: SkittlesType = { kind: "array" as SkittlesTypeKind, valueType: resultElemType };
+  const arrType: SkittlesType = { kind: SkittlesTypeKind.Array, valueType: resultElemType };
   const resultTypeName = typeToSolidityName(resultElemType);
   const body: Statement[] = [
     mkVarDecl("__sk_result", arrType, { kind: "new", callee: `${resultTypeName}[]`, args: [mkProp(arrayExpr, "length")] }),
@@ -1074,7 +1074,7 @@ function generateSortHelper(
 ): SkittlesFunction {
   const helperName = `_sort_${ctx.arrayMethodCounter++}`;
   const elemType = elementType ?? UINT256_TYPE;
-  const isAlreadySigned = elemType.kind === ("int256" as SkittlesTypeKind);
+  const isAlreadySigned = elemType.kind === (SkittlesTypeKind.Int256);
   const comparatorParamType = isAlreadySigned ? elemType : INT256_TYPE;
   // int256 cast helper: int256(expr) — only needed for uint256 elements
   const mkMaybeCast = (e: Expression): Expression =>
@@ -1140,7 +1140,7 @@ export function isMappingLikeReceiver(node: ts.Expression): boolean {
   if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
     const name = node.name.text;
     const type = ctx.currentVarTypes.get(name);
-    return type?.kind === ("mapping" as SkittlesTypeKind);
+    return type?.kind === (SkittlesTypeKind.Mapping);
   }
   if (ts.isElementAccessExpression(node)) {
     return isMappingLikeReceiver(node.expression);
@@ -1158,14 +1158,14 @@ function resolveMappingValueType(node: ts.Expression): SkittlesType | undefined 
   if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
     const name = node.name.text;
     const type = ctx.currentVarTypes.get(name);
-    if (type?.kind === ("mapping" as SkittlesTypeKind)) {
+    if (type?.kind === (SkittlesTypeKind.Mapping)) {
       return type.valueType;
     }
     return undefined;
   }
   if (ts.isElementAccessExpression(node)) {
     const parentValueType = resolveMappingValueType(node.expression);
-    if (parentValueType?.kind === ("mapping" as SkittlesTypeKind)) {
+    if (parentValueType?.kind === (SkittlesTypeKind.Mapping)) {
       return parentValueType.valueType;
     }
     return undefined;

--- a/src/compiler/mutability.ts
+++ b/src/compiler/mutability.ts
@@ -1,14 +1,14 @@
 import ts from "typescript";
-import type {
-  SkittlesParameter,
-  SkittlesType,
+import {
   SkittlesTypeKind,
-  SkittlesFunction,
-  SkittlesContractInterface,
-  SkittlesContract,
-  StateMutability,
-  Statement,
-  Expression,
+  type SkittlesParameter,
+  type SkittlesType,
+  type SkittlesFunction,
+  type SkittlesContractInterface,
+  type SkittlesContract,
+  type StateMutability,
+  type Statement,
+  type Expression,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import { inferType } from "./type-parser.ts";
@@ -204,7 +204,7 @@ export function collectExternalInterfaceCalls(
       expr.callee.object.object.name === "this"
     ) {
       const propType = stateVarTypes.get(expr.callee.object.property);
-      if (propType?.kind === ("contract-interface" as SkittlesTypeKind) && propType.structName) {
+      if (propType?.kind === (SkittlesTypeKind.ContractInterface) && propType.structName) {
         calls.push({ ifaceName: propType.structName, methodName });
       }
     }
@@ -215,14 +215,14 @@ export function collectExternalInterfaceCalls(
       expr.callee.object.name !== "this"
     ) {
       const varType = localVarTypes.get(expr.callee.object.name);
-      if (varType?.kind === ("contract-interface" as SkittlesTypeKind) && varType.structName) {
+      if (varType?.kind === (SkittlesTypeKind.ContractInterface) && varType.structName) {
         calls.push({ ifaceName: varType.structName, methodName });
       }
     }
   }, (stmt) => {
     // Track local variable declarations of contract-interface types
     if (stmt.kind === "variable-declaration" && stmt.type &&
-        stmt.type.kind === ("contract-interface" as SkittlesTypeKind) && stmt.name) {
+        stmt.type.kind === (SkittlesTypeKind.ContractInterface) && stmt.name) {
       localVarTypes.set(stmt.name, stmt.type);
     }
   });
@@ -265,7 +265,7 @@ export function rewriteInterfacePropertyGetters(
       expr.object.object.name === "this"
     ) {
       const propType = ctx.stateVarTypes.get(expr.object.property);
-      if (propType && propType.kind === ("contract-interface" as SkittlesTypeKind) && propType.structName) {
+      if (propType && propType.kind === (SkittlesTypeKind.ContractInterface) && propType.structName) {
         const iface = ctx.knownContractInterfaceMap.get(propType.structName);
         if (iface && iface.functions.some(f => f.name === expr.property)) return true;
       }
@@ -277,7 +277,7 @@ export function rewriteInterfacePropertyGetters(
       expr.object.name !== "this"
     ) {
       const varType = localVarTypes.get(expr.object.name) ?? varTypes.get(expr.object.name);
-      if (varType && varType.kind === ("contract-interface" as SkittlesTypeKind) && varType.structName) {
+      if (varType && varType.kind === (SkittlesTypeKind.ContractInterface) && varType.structName) {
         const iface = ctx.knownContractInterfaceMap.get(varType.structName);
         if (iface && iface.functions.some(f => f.name === expr.property)) return true;
       }
@@ -333,7 +333,7 @@ export function rewriteInterfacePropertyGetters(
         return { ...stmt, value: stmt.value ? transformExpr(stmt.value, false) : undefined };
       case "variable-declaration": {
         const transformed = { ...stmt, initializer: stmt.initializer ? transformExpr(stmt.initializer, false) : undefined };
-        if (stmt.type && stmt.type.kind === ("contract-interface" as SkittlesTypeKind) && stmt.name) {
+        if (stmt.type && stmt.type.kind === (SkittlesTypeKind.ContractInterface) && stmt.name) {
           localVarTypes.set(stmt.name, stmt.type);
         }
         return transformed;
@@ -454,7 +454,7 @@ export function inferStateMutability(body: Statement[], varTypes?: Map<string, S
         // Treat both typed addresses and explicit address(...) casts as address-like
         const objType = inferType(expr.object, combinedVarTypes);
         const isAddressLike =
-          objType?.kind === ("address" as SkittlesTypeKind) ||
+          objType?.kind === (SkittlesTypeKind.Address) ||
           (
             expr.object.kind === "call" &&
             expr.object.callee.kind === "identifier" &&
@@ -534,7 +534,7 @@ export function inferStateMutability(body: Statement[], varTypes?: Map<string, S
       if (stmt.kind === "variable-declaration" && stmt.type && stmt.name) {
         // Only track contract-interface typed locals in localVarTypes
         // (used for external call detection / .transfer() classification).
-        if (stmt.type.kind === ("contract-interface" as SkittlesTypeKind)) {
+        if (stmt.type.kind === (SkittlesTypeKind.ContractInterface)) {
           localVarTypes.set(stmt.name, stmt.type);
         }
         // Update combinedVarTypes so that inner shadowing declarations
@@ -543,9 +543,9 @@ export function inferStateMutability(body: Statement[], varTypes?: Map<string, S
         const existingType = combinedVarTypes.get(stmt.name);
         if (existingType) {
           const existingIsAddressLike =
-            existingType.kind === ("address" as SkittlesTypeKind);
+            existingType.kind === (SkittlesTypeKind.Address);
           const newIsAddressLike =
-            stmt.type.kind === ("address" as SkittlesTypeKind);
+            stmt.type.kind === (SkittlesTypeKind.Address);
           if (!existingIsAddressLike || newIsAddressLike) {
             combinedVarTypes.set(stmt.name, stmt.type);
           }
@@ -611,7 +611,7 @@ export function propagateMutability(contracts: SkittlesContract[]): void {
 }
 
 export function collectContractInterfaceTypeRefs(type: SkittlesType, refs: Set<string>): void {
-  if (type.kind === ("contract-interface" as SkittlesTypeKind) && type.structName) {
+  if (type.kind === (SkittlesTypeKind.ContractInterface) && type.structName) {
     refs.add(type.structName);
   }
   if (type.keyType) collectContractInterfaceTypeRefs(type.keyType, refs);
@@ -663,7 +663,7 @@ export function isExternalContractCall(expr: { callee: Expression }, varTypes: M
   ) {
     const propName = expr.callee.object.property;
     const propType = ctx.stateVarTypes.get(propName);
-    if (propType && propType.kind === ("contract-interface" as SkittlesTypeKind)) {
+    if (propType && propType.kind === (SkittlesTypeKind.ContractInterface)) {
       return true;
     }
   }
@@ -678,7 +678,7 @@ export function isExternalContractCallOnLocal(expr: { callee: Expression }, loca
   ) {
     const varName = expr.callee.object.name;
     const varType = localVarTypes.get(varName);
-    if (varType && varType.kind === ("contract-interface" as SkittlesTypeKind)) {
+    if (varType && varType.kind === (SkittlesTypeKind.ContractInterface)) {
       return true;
     }
   }
@@ -706,7 +706,7 @@ export function getExternalCallMethodMutability(
     varTypes
   ) {
     const propType = ctx.stateVarTypes.get(expr.callee.object.property);
-    if (propType?.kind === ("contract-interface" as SkittlesTypeKind)) {
+    if (propType?.kind === (SkittlesTypeKind.ContractInterface)) {
       ifaceName = propType.structName;
     }
   }
@@ -719,7 +719,7 @@ export function getExternalCallMethodMutability(
     localVarTypes
   ) {
     const varType = localVarTypes.get(expr.callee.object.name);
-    if (varType?.kind === ("contract-interface" as SkittlesTypeKind)) {
+    if (varType?.kind === (SkittlesTypeKind.ContractInterface)) {
       ifaceName = varType.structName;
     }
   }
@@ -757,14 +757,14 @@ export function isContractInterfaceReceiver(
     receiver.object.name === "this"
   ) {
     const propType = ctx.stateVarTypes.get(receiver.property);
-    if (propType && propType.kind === ("contract-interface" as SkittlesTypeKind)) return true;
+    if (propType && propType.kind === (SkittlesTypeKind.ContractInterface)) return true;
   }
   // token.transfer(...) where token is a contract-interface local/param
   if (receiver.kind === "identifier") {
     const localType = localVarTypes?.get(receiver.name);
-    if (localType && localType.kind === ("contract-interface" as SkittlesTypeKind)) return true;
+    if (localType && localType.kind === (SkittlesTypeKind.ContractInterface)) return true;
     const stateType = varTypes?.get(receiver.name);
-    if (stateType && stateType.kind === ("contract-interface" as SkittlesTypeKind)) return true;
+    if (stateType && stateType.kind === (SkittlesTypeKind.ContractInterface)) return true;
   }
   return false;
 }

--- a/src/compiler/parser-utils.ts
+++ b/src/compiler/parser-utils.ts
@@ -1,12 +1,12 @@
 import ts from "typescript";
-import { ADDRESS_LITERAL_RE } from "../types/index.ts";
-import type {
-  SkittlesParameter,
-  SkittlesType,
+import {
+  ADDRESS_LITERAL_RE,
   SkittlesTypeKind,
-  Visibility,
-  Statement,
-  Expression,
+  type SkittlesParameter,
+  type SkittlesType,
+  type Visibility,
+  type Statement,
+  type Expression,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 
@@ -20,7 +20,7 @@ export function setupStringTracking(parameters: SkittlesParameter[], varTypes: M
   ctx.currentStringNames = new Set();
   ctx.currentParamTypes = new Map();
   for (const param of parameters) {
-    if (param.type.kind === ("string" as SkittlesTypeKind)) {
+    if (param.type.kind === (SkittlesTypeKind.String)) {
       ctx.currentStringNames.add(param.name);
     }
     ctx.currentParamTypes.set(param.name, param.type);
@@ -42,7 +42,7 @@ export function isStringExpr(expr: Expression): boolean {
     // For this.<prop>, always use the original state-var type map so that
     // local/param shadowing doesn't affect state-variable type resolution.
     const type = ctx.stateVarTypes.get(expr.property);
-    return type?.kind === ("string" as SkittlesTypeKind);
+    return type?.kind === (SkittlesTypeKind.String);
   }
   if (
     expr.kind === "call" &&
@@ -228,9 +228,9 @@ export function mkReturn(value?: Expression): Statement { return { kind: "return
 export function mkIf(cond: Expression, thenBody: Statement[], elseBody?: Statement[]): Statement {
   return { kind: "if", condition: cond, thenBody, elseBody };
 }
-export const UINT256_TYPE: SkittlesType = { kind: "uint256" as SkittlesTypeKind };
-export const INT256_TYPE: SkittlesType = { kind: "int256" as SkittlesTypeKind };
-export const BOOL_TYPE: SkittlesType = { kind: "bool" as SkittlesTypeKind };
+export const UINT256_TYPE: SkittlesType = { kind: SkittlesTypeKind.Uint256 };
+export const INT256_TYPE: SkittlesType = { kind: SkittlesTypeKind.Int256 };
+export const BOOL_TYPE: SkittlesType = { kind: SkittlesTypeKind.Bool };
 
 export const BUILTIN_IDENTIFIERS = new Set(["msg", "block", "tx", "self", "type", "abi", "this", "super"]);
 
@@ -319,17 +319,17 @@ export function mkForLoop(
 
 export function typeToSolidityName(type: SkittlesType): string {
   switch (type.kind) {
-    case "uint256" as SkittlesTypeKind: return "uint256";
-    case "int256" as SkittlesTypeKind: return "int256";
-    case "address" as SkittlesTypeKind: return "address";
-    case "bool" as SkittlesTypeKind: return "bool";
-    case "string" as SkittlesTypeKind: return "string";
-    case "bytes32" as SkittlesTypeKind: return "bytes32";
-    case "bytes" as SkittlesTypeKind: return "bytes";
-    case "struct" as SkittlesTypeKind: return type.structName ?? "UnknownStruct";
-    case "enum" as SkittlesTypeKind: return type.structName ?? "UnknownEnum";
-    case "contract-interface" as SkittlesTypeKind: return type.structName ?? "UnknownInterface";
-    case "array" as SkittlesTypeKind: return `${typeToSolidityName(type.valueType!)}[]`;
+    case SkittlesTypeKind.Uint256: return "uint256";
+    case SkittlesTypeKind.Int256: return "int256";
+    case SkittlesTypeKind.Address: return "address";
+    case SkittlesTypeKind.Bool: return "bool";
+    case SkittlesTypeKind.String: return "string";
+    case SkittlesTypeKind.Bytes32: return "bytes32";
+    case SkittlesTypeKind.Bytes: return "bytes";
+    case SkittlesTypeKind.Struct: return type.structName ?? "UnknownStruct";
+    case SkittlesTypeKind.Enum: return type.structName ?? "UnknownEnum";
+    case SkittlesTypeKind.ContractInterface: return type.structName ?? "UnknownInterface";
+    case SkittlesTypeKind.Array: return `${typeToSolidityName(type.valueType!)}[]`;
     default: return "uint256";
   }
 }
@@ -341,17 +341,17 @@ export function getArrayHelperSuffix(elementType: SkittlesType | undefined): str
 
 export function identifierSafeType(type: SkittlesType): string {
   switch (type.kind) {
-    case "uint256" as SkittlesTypeKind: return "uint256";
-    case "int256" as SkittlesTypeKind: return "int256";
-    case "address" as SkittlesTypeKind: return "address";
-    case "bool" as SkittlesTypeKind: return "bool";
-    case "string" as SkittlesTypeKind: return "string";
-    case "bytes32" as SkittlesTypeKind: return "bytes32";
-    case "bytes" as SkittlesTypeKind: return "bytes";
-    case "struct" as SkittlesTypeKind: return type.structName ?? "UnknownStruct";
-    case "enum" as SkittlesTypeKind: return type.structName ?? "UnknownEnum";
-    case "contract-interface" as SkittlesTypeKind: return type.structName ?? "UnknownInterface";
-    case "array" as SkittlesTypeKind: return `arr_${identifierSafeType(type.valueType!)}`;
+    case SkittlesTypeKind.Uint256: return "uint256";
+    case SkittlesTypeKind.Int256: return "int256";
+    case SkittlesTypeKind.Address: return "address";
+    case SkittlesTypeKind.Bool: return "bool";
+    case SkittlesTypeKind.String: return "string";
+    case SkittlesTypeKind.Bytes32: return "bytes32";
+    case SkittlesTypeKind.Bytes: return "bytes";
+    case SkittlesTypeKind.Struct: return type.structName ?? "UnknownStruct";
+    case SkittlesTypeKind.Enum: return type.structName ?? "UnknownEnum";
+    case SkittlesTypeKind.ContractInterface: return type.structName ?? "UnknownInterface";
+    case SkittlesTypeKind.Array: return `arr_${identifierSafeType(type.valueType!)}`;
     default: return "uint256";
   }
 }
@@ -359,12 +359,12 @@ export function identifierSafeType(type: SkittlesType): string {
 export function defaultValueForType(type: SkittlesType | undefined): Expression | null {
   if (!type) return null;
   switch (type.kind) {
-    case "uint256" as SkittlesTypeKind:
-    case "int256" as SkittlesTypeKind:
+    case SkittlesTypeKind.Uint256:
+    case SkittlesTypeKind.Int256:
       return { kind: "number-literal", value: "0" };
-    case "bool" as SkittlesTypeKind:
+    case SkittlesTypeKind.Bool:
       return { kind: "boolean-literal", value: false };
-    case "address" as SkittlesTypeKind:
+    case SkittlesTypeKind.Address:
       return { kind: "identifier", name: "address(0)" };
     default:
       return null;

--- a/src/compiler/statement-parser.ts
+++ b/src/compiler/statement-parser.ts
@@ -1,13 +1,13 @@
 import ts from "typescript";
-import type {
-  SkittlesType,
+import {
   SkittlesTypeKind,
-  SkittlesParameter,
-  Statement,
-  Expression,
-  EmitStatement,
-  ConsoleLogStatement,
-  SwitchCase,
+  type SkittlesType,
+  type SkittlesParameter,
+  type Statement,
+  type Expression,
+  type EmitStatement,
+  type ConsoleLogStatement,
+  type SwitchCase,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import {
@@ -81,7 +81,7 @@ export function parseArrayDestructuring(
       ctx.currentStringNames.delete(name);
       if (type) {
         varTypes.set(name, type);
-        if (type.kind === ("string" as SkittlesTypeKind)) {
+        if (type.kind === (SkittlesTypeKind.String)) {
           ctx.currentStringNames.add(name);
         }
       }
@@ -133,7 +133,7 @@ export function parseArrayDestructuring(
       ctx.currentStringNames.delete(name);
       if (type) {
         varTypes.set(name, type);
-        if (type.kind === ("string" as SkittlesTypeKind)) {
+        if (type.kind === (SkittlesTypeKind.String)) {
           ctx.currentStringNames.add(name);
         }
       }
@@ -166,7 +166,7 @@ export function parseArrayDestructuring(
       }
     }
 
-    if (tupleType?.kind === ("tuple" as SkittlesTypeKind) && tupleType.tupleTypes) {
+    if (tupleType?.kind === (SkittlesTypeKind.Tuple) && tupleType.tupleTypes) {
       const tupleArity = tupleType.tupleTypes.length;
       const names: (string | null)[] = [];
       const types: (SkittlesType | null)[] = [];
@@ -194,7 +194,7 @@ export function parseArrayDestructuring(
           const t = tupleType.tupleTypes[i];
           types.push(t);
           varTypes.set(bindingName, t);
-          if (t && t.kind === ("string" as SkittlesTypeKind)) {
+          if (t && t.kind === (SkittlesTypeKind.String)) {
             ctx.currentStringNames.add(bindingName);
           } else {
             ctx.currentStringNames.delete(bindingName);
@@ -303,7 +303,7 @@ export function parseObjectDestructuring(
       ctx.currentStringNames.delete(name);
       if (type) {
         varTypes.set(name, type);
-        if (type.kind === ("string" as SkittlesTypeKind)) {
+        if (type.kind === (SkittlesTypeKind.String)) {
           ctx.currentStringNames.add(name);
         }
       }
@@ -347,7 +347,7 @@ export function parseObjectDestructuring(
 
   const initExpr = parseExpression(initializer);
 
-  if (structType?.kind === ("struct" as SkittlesTypeKind) && structType.structName) {
+  if (structType?.kind === (SkittlesTypeKind.Struct) && structType.structName) {
     // Temp variable + field accesses (use __sk_ prefix + counter to avoid collisions)
     const tempName = `__sk_${structType.structName.charAt(0).toLowerCase()}${structType.structName.slice(1)}_${ctx.destructureCounter++}`;
     statements.push({
@@ -392,7 +392,7 @@ export function parseObjectDestructuring(
         );
       }
       varTypes.set(name, fieldType);
-      if (fieldType.kind === ("string" as SkittlesTypeKind)) {
+      if (fieldType.kind === (SkittlesTypeKind.String)) {
         ctx.currentStringNames.add(name);
       } else {
         ctx.currentStringNames.delete(name);
@@ -456,7 +456,7 @@ export function parseObjectDestructuring(
       ctx.currentStringNames.delete(name);
       if (type) {
         varTypes.set(name, type);
-        if (type.kind === ("string" as SkittlesTypeKind)) {
+        if (type.kind === (SkittlesTypeKind.String)) {
           ctx.currentStringNames.add(name);
         }
       }
@@ -502,7 +502,7 @@ export function parseStatement(
     const type =
       explicitType || (initializer ? inferType(initializer, varTypes) : undefined);
 
-    if (type?.kind === ("string" as SkittlesTypeKind)) {
+    if (type?.kind === (SkittlesTypeKind.String)) {
       ctx.currentStringNames.add(name);
     } else {
       ctx.currentStringNames.delete(name);
@@ -647,7 +647,7 @@ export function parseStatement(
         const resolvedType = loopVarTypes.get(name);
         // Remove any outer tracking for this name; re-add only if string.
         loopStringNames.delete(name);
-        if (resolvedType?.kind === ("string" as SkittlesTypeKind)) {
+        if (resolvedType?.kind === (SkittlesTypeKind.String)) {
           loopStringNames.add(name);
         }
       }
@@ -721,7 +721,7 @@ export function parseStatement(
     // When no explicit type annotation, infer element type from the iterated expression
     const itemTypeNode = explicitType ?? (() => {
       const arrType = inferType(arrExpr, varTypes);
-      if (arrType?.kind === ("array" as SkittlesTypeKind) && arrType.valueType) {
+      if (arrType?.kind === (SkittlesTypeKind.Array) && arrType.valueType) {
         return arrType.valueType;
       }
       return undefined;
@@ -732,7 +732,7 @@ export function parseStatement(
     if (itemTypeNode) {
       loopVarTypes.set(itemName, itemTypeNode);
     }
-    loopVarTypes.set(indexName, { kind: "uint256" as SkittlesTypeKind });
+    loopVarTypes.set(indexName, { kind: SkittlesTypeKind.Uint256 });
 
     // Temporarily switch parser context to loop-scoped var types
     const previousVarTypes = ctx.currentVarTypes;
@@ -740,7 +740,7 @@ export function parseStatement(
     const loopStringNames = new Set(previousStringNames);
     // Shadowing: ensure any outer string classification for `itemName` doesn't leak into the loop scope
     loopStringNames.delete(itemName);
-    if (itemTypeNode && itemTypeNode.kind === ("string" as SkittlesTypeKind)) {
+    if (itemTypeNode && itemTypeNode.kind === (SkittlesTypeKind.String)) {
       loopStringNames.add(itemName);
     }
     let innerBody: Statement[];
@@ -771,7 +771,7 @@ export function parseStatement(
       initializer: {
         kind: "variable-declaration",
         name: indexName,
-        type: { kind: "uint256" as SkittlesTypeKind },
+        type: { kind: SkittlesTypeKind.Uint256 },
         initializer: { kind: "number-literal", value: "0" },
       },
       condition: {
@@ -810,8 +810,8 @@ export function parseStatement(
 
       const indexName = `__sk_i_${itemName}`;
       const loopVarTypes = new Map(varTypes);
-      loopVarTypes.set(itemName, { kind: "enum" as SkittlesTypeKind, structName: enumName });
-      loopVarTypes.set(indexName, { kind: "uint256" as SkittlesTypeKind });
+      loopVarTypes.set(itemName, { kind: SkittlesTypeKind.Enum, structName: enumName });
+      loopVarTypes.set(indexName, { kind: SkittlesTypeKind.Uint256 });
 
       // Temporarily switch parser context to loop-scoped var types
       const previousVarTypes = ctx.currentVarTypes;
@@ -834,7 +834,7 @@ export function parseStatement(
       const itemDecl: Statement = {
         kind: "variable-declaration",
         name: itemName,
-        type: { kind: "enum" as SkittlesTypeKind, structName: enumName },
+        type: { kind: SkittlesTypeKind.Enum, structName: enumName },
         initializer: {
           kind: "call",
           callee: { kind: "identifier", name: enumName },
@@ -847,7 +847,7 @@ export function parseStatement(
         initializer: {
           kind: "variable-declaration",
           name: indexName,
-          type: { kind: "uint256" as SkittlesTypeKind },
+          type: { kind: SkittlesTypeKind.Uint256 },
           initializer: { kind: "number-literal", value: "0" },
         },
         condition: {
@@ -1032,7 +1032,7 @@ export function parseStatements(
           : undefined;
         const type =
           explicitType || (initializer ? inferType(initializer, varTypes) : undefined);
-        if (type?.kind === ("string" as SkittlesTypeKind)) {
+        if (type?.kind === (SkittlesTypeKind.String)) {
           ctx.currentStringNames.add(name);
         } else {
           ctx.currentStringNames.delete(name);

--- a/src/compiler/type-parser.ts
+++ b/src/compiler/type-parser.ts
@@ -1,10 +1,10 @@
 import ts from "typescript";
-import { ADDRESS_LITERAL_RE } from "../types/index.ts";
-import type {
-  SkittlesParameter,
-  SkittlesType,
+import {
+  ADDRESS_LITERAL_RE,
   SkittlesTypeKind,
-  Expression,
+  type SkittlesParameter,
+  type SkittlesType,
+  type Expression,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import { STRING_RETURNING_HELPERS } from "./parser-utils.ts";
@@ -20,7 +20,7 @@ export function parseTypeLiteralFields(node: ts.TypeLiteralNode): SkittlesParame
       const name = member.name.text;
       const type: SkittlesType = member.type
         ? parseType(member.type)
-        : { kind: "uint256" as SkittlesTypeKind };
+        : { kind: SkittlesTypeKind.Uint256 };
       fields.push({ name, type });
     }
   }
@@ -36,7 +36,7 @@ export function parseType(node: ts.TypeNode): SkittlesType {
           "Please remove the 'asserts' modifier or refactor this function."
       );
     }
-    return { kind: "bool" as SkittlesTypeKind };
+    return { kind: SkittlesTypeKind.Bool };
   }
 
   if (ts.isTypeReferenceNode(node)) {
@@ -50,7 +50,7 @@ export function parseType(node: ts.TypeNode): SkittlesType {
       node.typeArguments.length === 2
     ) {
       return {
-        kind: "mapping" as SkittlesTypeKind,
+        kind: SkittlesTypeKind.Mapping,
         keyType: parseType(node.typeArguments[0]),
         valueType: parseType(node.typeArguments[1]),
       };
@@ -62,18 +62,18 @@ export function parseType(node: ts.TypeNode): SkittlesType {
       node.typeArguments.length === 1
     ) {
       return {
-        kind: "array" as SkittlesTypeKind,
+        kind: SkittlesTypeKind.Array,
         valueType: parseType(node.typeArguments[0]),
       };
     }
 
-    if (name === "address") return { kind: "address" as SkittlesTypeKind };
-    if (name === "bytes") return { kind: "bytes" as SkittlesTypeKind };
-    if (name === "bytes32") return { kind: "bytes32" as SkittlesTypeKind };
+    if (name === "address") return { kind: SkittlesTypeKind.Address };
+    if (name === "bytes") return { kind: SkittlesTypeKind.Bytes };
+    if (name === "bytes32") return { kind: SkittlesTypeKind.Bytes32 };
 
     if (ctx.knownStructs.has(name)) {
       return {
-        kind: "struct" as SkittlesTypeKind,
+        kind: SkittlesTypeKind.Struct,
         structName: name,
         structFields: ctx.knownStructs.get(name),
       };
@@ -81,14 +81,14 @@ export function parseType(node: ts.TypeNode): SkittlesType {
 
     if (ctx.knownContractInterfaces.has(name)) {
       return {
-        kind: "contract-interface" as SkittlesTypeKind,
+        kind: SkittlesTypeKind.ContractInterface,
         structName: name,
       };
     }
 
     if (ctx.knownEnums.has(name)) {
       return {
-        kind: "enum" as SkittlesTypeKind,
+        kind: SkittlesTypeKind.Enum,
         structName: name,
       };
     }
@@ -98,7 +98,7 @@ export function parseType(node: ts.TypeNode): SkittlesType {
 
   if (ts.isArrayTypeNode(node)) {
     return {
-      kind: "array" as SkittlesTypeKind,
+      kind: SkittlesTypeKind.Array,
       valueType: parseType(node.elementType),
     };
   }
@@ -109,7 +109,7 @@ export function parseType(node: ts.TypeNode): SkittlesType {
 
   if (ts.isTupleTypeNode(node)) {
     return {
-      kind: "tuple" as SkittlesTypeKind,
+      kind: SkittlesTypeKind.Tuple,
       tupleTypes: node.elements.map((el) => {
         if (ts.isNamedTupleMember(el)) {
           return parseType(el.type);
@@ -121,13 +121,13 @@ export function parseType(node: ts.TypeNode): SkittlesType {
 
   switch (node.kind) {
     case ts.SyntaxKind.NumberKeyword:
-      return { kind: "uint256" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.Uint256 };
     case ts.SyntaxKind.StringKeyword:
-      return { kind: "string" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.String };
     case ts.SyntaxKind.BooleanKeyword:
-      return { kind: "bool" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.Bool };
     case ts.SyntaxKind.VoidKeyword:
-      return { kind: "void" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.Void };
     default:
       throw new Error(`Unsupported type node kind: ${ts.SyntaxKind[node.kind]}. Skittles supports number, string, boolean, address, bytes, bytes32, Record<K,V>, and T[].`);
   }
@@ -139,23 +139,23 @@ export function inferType(
 ): SkittlesType | undefined {
   switch (expr.kind) {
     case "number-literal":
-      return { kind: "uint256" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.Uint256 };
     case "string-literal":
       if (ADDRESS_LITERAL_RE.test(expr.value))
-        return { kind: "address" as SkittlesTypeKind };
-      return { kind: "string" as SkittlesTypeKind };
+        return { kind: SkittlesTypeKind.Address };
+      return { kind: SkittlesTypeKind.String };
     case "boolean-literal":
-      return { kind: "bool" as SkittlesTypeKind };
+      return { kind: SkittlesTypeKind.Bool };
     case "identifier":
       if (expr.name === "self")
-        return { kind: "address" as SkittlesTypeKind };
+        return { kind: SkittlesTypeKind.Address };
       return varTypes.get(expr.name);
     case "property-access":
       // addr.balance → uint256 (ETH balance of an address)
       if (expr.property === "balance") {
         const objType = inferType(expr.object, varTypes);
-        if (objType?.kind === ("address" as SkittlesTypeKind))
-          return { kind: "uint256" as SkittlesTypeKind };
+        if (objType?.kind === (SkittlesTypeKind.Address))
+          return { kind: SkittlesTypeKind.Uint256 };
       }
       if (expr.object.kind === "identifier") {
         if (expr.object.name === "this") {
@@ -165,31 +165,31 @@ export function inferType(
         }
         if (expr.object.name === "msg") {
           if (expr.property === "sender")
-            return { kind: "address" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Address };
           if (expr.property === "value")
-            return { kind: "uint256" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Uint256 };
           if (expr.property === "data")
-            return { kind: "bytes" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Bytes };
           if (expr.property === "sig")
-            return { kind: "bytes32" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Bytes32 };
         }
         if (expr.object.name === "block") {
           if (expr.property === "coinbase")
-            return { kind: "address" as SkittlesTypeKind };
-          return { kind: "uint256" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Address };
+          return { kind: SkittlesTypeKind.Uint256 };
         }
         if (expr.object.name === "tx") {
           if (expr.property === "origin")
-            return { kind: "address" as SkittlesTypeKind };
-          return { kind: "uint256" as SkittlesTypeKind };
+            return { kind: SkittlesTypeKind.Address };
+          return { kind: SkittlesTypeKind.Uint256 };
         }
       }
       return undefined;
     case "element-access": {
       const objType = inferType(expr.object, varTypes);
-      if (objType?.kind === ("mapping" as SkittlesTypeKind))
+      if (objType?.kind === (SkittlesTypeKind.Mapping))
         return objType.valueType;
-      if (objType?.kind === ("array" as SkittlesTypeKind))
+      if (objType?.kind === (SkittlesTypeKind.Array))
         return objType.valueType;
       return undefined;
     }
@@ -199,12 +199,12 @@ export function inferType(
           expr.operator
         )
       ) {
-        return { kind: "bool" as SkittlesTypeKind };
+        return { kind: SkittlesTypeKind.Bool };
       }
       return inferType(expr.left, varTypes);
     case "unary":
       if (expr.operator === "!")
-        return { kind: "bool" as SkittlesTypeKind };
+        return { kind: SkittlesTypeKind.Bool };
       return inferType(expr.operand, varTypes);
     case "conditional": {
       const trueType = inferType(expr.whenTrue, varTypes);
@@ -216,19 +216,19 @@ export function inferType(
       if (expr.callee.kind === "identifier") {
         // address(...) cast returns address type
         if (expr.callee.name === "address") {
-          return { kind: "address" as SkittlesTypeKind };
+          return { kind: SkittlesTypeKind.Address };
         }
         if (expr.callee.name === "keccak256" || expr.callee.name === "sha256" || expr.callee.name === "hash") {
-          return { kind: "bytes32" as SkittlesTypeKind };
+          return { kind: SkittlesTypeKind.Bytes32 };
         }
         if (STRING_RETURNING_HELPERS.has(expr.callee.name)) {
-          return { kind: "string" as SkittlesTypeKind };
+          return { kind: SkittlesTypeKind.String };
         }
         if (expr.callee.name === "_startsWith" || expr.callee.name === "_endsWith") {
-          return { kind: "bool" as SkittlesTypeKind };
+          return { kind: SkittlesTypeKind.Bool };
         }
         if (expr.callee.name === "_split") {
-          return { kind: "array" as SkittlesTypeKind, valueType: { kind: "string" as SkittlesTypeKind } };
+          return { kind: SkittlesTypeKind.Array, valueType: { kind: SkittlesTypeKind.String } };
         }
       }
       return undefined;


### PR DESCRIPTION
Closes #275

## Problem

Throughout `src/compiler/parser.ts`, type kinds are frequently used as string casts instead of the `SkittlesTypeKind` enum:

```typescript
// Current pattern (parser.ts line 59):
if (param.type.kind === ("string" as SkittlesTypeKind)) {

// In codegen.ts, the enum is used properly:
case SkittlesTypeKind.Uint256:
  return "uint256";
```

The parser uses patterns like `"uint256" as SkittlesTypeKind`, `"string" as SkittlesTypeKind`, etc. in many places, while codegen.ts correctly uses the enum values like `SkittlesTypeKind.Uint256`, `SkittlesTypeKind.String`.

## Why This Matters

- String casts bypass the enum's type safety; typos won't be caught at compile time
- Inconsistent with the pattern used in codegen.ts
- Makes it harder to refactor if enum values ever change

## Suggested Fix

Replace all `"..." as SkittlesTypeKind` casts with the corresponding `SkittlesTypeKind.X` enum value throughout parser.ts.