### PR TITLE
Cleanup: isSuperCall and getSuperCallArgs duplicate the same condition in codegen.ts [XS]

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -1546,12 +1546,7 @@ function generateFunction(f: SkittlesFunction): string {
 }
 
 function isSuperCall(stmt: Statement): boolean {
-  return (
-    stmt.kind === "expression" &&
-    stmt.expression.kind === "call" &&
-    stmt.expression.callee.kind === "identifier" &&
-    stmt.expression.callee.name === "super"
-  );
+  return getSuperCallArgs(stmt) !== null;
 }
 
 function getSuperCallArgs(stmt: Statement): Expression[] | null {


### PR DESCRIPTION
Closes #271

## Problem

In `src/compiler/codegen.ts`, two functions check for the exact same condition:

**isSuperCall** (lines 1549–1556):
```typescript
function isSuperCall(stmt: Statement): boolean {
  return (
    stmt.kind === "expression" &&
    stmt.expression.kind === "call" &&
    stmt.expression.callee.kind === "identifier" &&
    stmt.expression.callee.name === "super"
  );
}
```

**getSuperCallArgs** (lines 1558–1568):
```typescript
function getSuperCallArgs(stmt: Statement): Expression[] | null {
  if (
    stmt.kind === "expression" &&
    stmt.expression.kind === "call" &&
    stmt.expression.callee.kind === "identifier" &&
    stmt.expression.callee.name === "super"
  ) {
    return stmt.expression.args;
  }
  return null;
}
```

The same four-line condition is duplicated verbatim.

## Suggested Fix

Have `getSuperCallArgs` be the single source of truth, and define `isSuperCall` in terms of it:

```typescript
function isSuperCall(stmt: Statement): boolean {
  return getSuperCallArgs(stmt) !== null;
}
```