### PR TITLE
Cleanup: Empty catch blocks swallow errors silently in compiler.ts [S]

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -159,8 +159,9 @@ export async function compile(
       if (classNames.length > 0) {
         preScanContractFiles.push(baseName);
       }
-    } catch {
-      // Errors will be caught in the main compilation loop below
+    } catch (err) {
+      // Pre-scan failed; will be re-reported during full compilation
+      logWarning(`Pre-scan failed for ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -216,8 +217,9 @@ export async function compile(
       if (classNames.length > 0) {
         preScanContractFiles.push(baseName);
       }
-    } catch {
-      // Errors handled in the main compilation loop
+    } catch (err) {
+      // Pre-scan failed; will be re-reported during full compilation
+      logWarning(`Pre-scan failed for ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 


### PR DESCRIPTION
Closes #273

## Problem

`src/compiler/compiler.ts` has two empty catch blocks during the pre-scan phase:

**Line 156–158** (user file pre-scan):
```typescript
} catch {
  // Errors will be caught in the main compilation loop below
}
```

**Line 213–215** (stdlib file pre-scan):
```typescript
} catch {
  // Errors handled in the main compilation loop
}
```

While the comment explains the intent (errors will surface later during full parsing), this pattern is fragile:

1. If the main compilation loop also has error handling issues, the root cause is lost
2. Different error types (filesystem errors vs parse errors vs type errors) are all treated the same
3. No diagnostic information is preserved for debugging

## Suggested Fix

At minimum, log a debug-level warning:

```typescript
} catch (err) {
  // Pre-scan failed; will be re-reported during full compilation
  logWarning(`Pre-scan failed for ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
}
```

Or, collect pre-scan errors and only suppress them if the main compilation loop also reports them.