### PR TITLE
Cleanup: Hardcoded external URLs in webapp should be centralized [XS]

### DIFF
--- a/docs/constants.ts
+++ b/docs/constants.ts
@@ -1,0 +1,5 @@
+export const URLS = {
+  website: "https://skittles.dev",
+  github: "https://github.com/chase-manning/skittles",
+  npm: "https://www.npmjs.com/package/skittles",
+};

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
+import { URLS } from "./constants";
 
 const config: Config = {
   title: "Skittles Docs",
@@ -62,17 +63,17 @@ const config: Config = {
       },
       items: [
         {
-          href: "https://skittles.dev",
+          href: URLS.website,
           label: "Website",
           position: "right",
         },
         {
-          href: "https://www.npmjs.com/package/skittles",
+          href: URLS.npm,
           label: "npm",
           position: "right",
         },
         {
-          href: "https://github.com/chase-manning/skittles",
+          href: URLS.github,
           label: "GitHub",
           position: "right",
         },
@@ -107,11 +108,11 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/chase-manning/skittles",
+              href: URLS.github,
             },
             {
               label: "npm",
-              href: "https://www.npmjs.com/package/skittles",
+              href: URLS.npm,
             },
           ],
         },
@@ -120,7 +121,7 @@ const config: Config = {
           items: [
             {
               label: "Website",
-              href: "https://skittles.dev",
+              href: URLS.website,
             },
           ],
         },

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, createContext, useContext, lazy, Suspense } from "react";
 import { Zap, Shuffle, Code, Shield, Layers, Timer } from "lucide-react";
 import "./App.css";
+import { URLS } from "./constants.ts";
 
 const Playground = lazy(() => import("./Playground.tsx"));
 
@@ -9,7 +10,7 @@ const VersionContext = createContext<string | null>(null);
 function useNpmVersion() {
   const [version, setVersion] = useState<string | null>(null);
   useEffect(() => {
-    fetch("https://registry.npmjs.org/skittles/latest")
+    fetch(URLS.npmApi)
       .then((res) => res.json())
       .then((data) => {
         if (data.version) setVersion(data.version);
@@ -37,16 +38,16 @@ function Header() {
         <a href="#playground" className="nav-link">
           Playground
         </a>
-        <a href="https://docs.skittles.dev" className="nav-link">
+        <a href={URLS.docs} className="nav-link">
           Docs
         </a>
-        <a href="https://github.com/chase-manning/skittles" target="_blank" rel="noopener noreferrer" className="nav-link">
+        <a href={URLS.github} target="_blank" rel="noopener noreferrer" className="nav-link">
           GitHub
         </a>
-        <a href="https://github.com/chase-manning/skittles/tree/main/example" target="_blank" rel="noopener noreferrer" className="nav-link">
+        <a href={URLS.githubExamples} target="_blank" rel="noopener noreferrer" className="nav-link">
           Examples
         </a>
-        <a href="https://www.npmjs.com/package/skittles" target="_blank" rel="noopener noreferrer" className="nav-link">
+        <a href={URLS.npm} target="_blank" rel="noopener noreferrer" className="nav-link">
           npm
         </a>
         <a href="#get-started" className="header-cta">
@@ -237,7 +238,7 @@ function Hero() {
         </p>
       </div>
       <div className="hero-actions">
-        <a href="https://docs.skittles.dev" className="btn-primary">
+        <a href={URLS.docs} className="btn-primary">
           <span>Read the Docs</span>
           <span>&rarr;</span>
         </a>
@@ -518,11 +519,11 @@ function FinalCTA() {
         MIT licensed. Node.js 22+. Works with every EVM toolchain.
       </p>
       <div className="final-cta-actions">
-        <a href="https://docs.skittles.dev" className="btn-primary btn-primary--lg">
+        <a href={URLS.docs} className="btn-primary btn-primary--lg">
           <span>Read the Docs</span>
           <span>&rarr;</span>
         </a>
-        <a href="https://github.com/chase-manning/skittles" target="_blank" rel="noopener noreferrer" className="btn-secondary btn-secondary--lg">
+        <a href={URLS.github} target="_blank" rel="noopener noreferrer" className="btn-secondary btn-secondary--lg">
           <span>GitHub</span>
         </a>
       </div>
@@ -546,20 +547,20 @@ function Footer() {
         <div className="footer-cols">
           <div className="footer-col">
             <span className="footer-col-title">PRODUCT</span>
-            <a href="https://docs.skittles.dev" className="footer-link">Documentation</a>
+            <a href={URLS.docs} className="footer-link">Documentation</a>
             <a href="#playground" className="footer-link">Playground</a>
-            <a href="https://github.com/chase-manning/skittles/tree/main/example" target="_blank" rel="noopener noreferrer" className="footer-link">Examples</a>
-            <a href="https://github.com/chase-manning/skittles/releases" target="_blank" rel="noopener noreferrer" className="footer-link">Changelog</a>
+            <a href={URLS.githubExamples} target="_blank" rel="noopener noreferrer" className="footer-link">Examples</a>
+            <a href={URLS.githubReleases} target="_blank" rel="noopener noreferrer" className="footer-link">Changelog</a>
           </div>
           <div className="footer-col">
             <span className="footer-col-title">COMMUNITY</span>
-            <a href="https://github.com/chase-manning/skittles" target="_blank" rel="noopener noreferrer" className="footer-link">GitHub</a>
-            <a href="https://www.npmjs.com/package/skittles" target="_blank" rel="noopener noreferrer" className="footer-link">npm</a>
-            <a href="https://github.com/chase-manning/skittles/issues" target="_blank" rel="noopener noreferrer" className="footer-link">Issues</a>
+            <a href={URLS.github} target="_blank" rel="noopener noreferrer" className="footer-link">GitHub</a>
+            <a href={URLS.npm} target="_blank" rel="noopener noreferrer" className="footer-link">npm</a>
+            <a href={URLS.githubIssues} target="_blank" rel="noopener noreferrer" className="footer-link">Issues</a>
           </div>
           <div className="footer-col">
             <span className="footer-col-title">LEGAL</span>
-            <a href="https://github.com/chase-manning/skittles/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="footer-link">MIT License</a>
+            <a href={URLS.githubLicense} target="_blank" rel="noopener noreferrer" className="footer-link">MIT License</a>
           </div>
         </div>
       </div>

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,0 +1,11 @@
+export const URLS = {
+  docs: "https://docs.skittles.dev",
+  github: "https://github.com/chase-manning/skittles",
+  githubExamples: "https://github.com/chase-manning/skittles/tree/main/example",
+  githubReleases: "https://github.com/chase-manning/skittles/releases",
+  githubIssues: "https://github.com/chase-manning/skittles/issues",
+  githubLicense:
+    "https://github.com/chase-manning/skittles/blob/main/LICENSE",
+  npm: "https://www.npmjs.com/package/skittles",
+  npmApi: "https://registry.npmjs.org/skittles/latest",
+};


### PR DESCRIPTION
Closes #269

## Problem

`webapp/src/App.tsx` has multiple hardcoded URLs scattered throughout the JSX:

- `https://docs.skittles.dev/`
- `https://github.com/chase-manning/skittles`
- `https://www.npmjs.com/package/skittles`
- `https://docs.skittles.dev/getting-started/installation`
- `https://docs.skittles.dev/getting-started/quick-start`
- `https://docs.skittles.dev/examples/token`
- npm version API URL

These are repeated in both the navbar and footer sections.

## Suggested Fix

Create a `constants.ts` file:

```typescript
export const URLS = {
  docs: "https://docs.skittles.dev",
  github: "https://github.com/chase-manning/skittles",
  npm: "https://www.npmjs.com/package/skittles",
  // ...
};
```

Also applies to `docs/docusaurus.config.ts` where GitHub and npm URLs are repeated in both navbar and footer.