### PR TITLE
Cleanup: Deep relative imports in webapp/src/compiler.ts [XS]

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -47,6 +47,18 @@ export type SkittlesError<
  */
 export type Indexed<T> = T;
 
+// Compiler API (parser + codegen)
+export {
+  parse,
+  collectTypes,
+  collectFunctions,
+  collectClassNames,
+} from "./compiler/parser.ts";
+export {
+  generateSolidity,
+  generateSolidityFile,
+} from "./compiler/codegen.ts";
+
 // Contract IR types (for advanced users / plugins)
 export type {
   SkittlesContract,

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -1,5 +1,4 @@
-import { parse, collectTypes, collectFunctions } from "../../src/compiler/parser.ts";
-import { generateSolidity, generateSolidityFile } from "../../src/compiler/codegen.ts";
+import { parse, collectTypes, collectFunctions, generateSolidity, generateSolidityFile } from "skittles";
 
 export interface CompileResult {
   solidity: string;

--- a/webapp/tsconfig.app.json
+++ b/webapp/tsconfig.app.json
@@ -15,6 +15,9 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "paths": {
+      "skittles": ["../src/exports.ts"]
+    },
 
     /* Linting */
     "strict": true,

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      skittles: path.resolve(__dirname, '../src/exports.ts'),
+    },
+  },
   server: {
     fs: {
       allow: ['.', '../src'],


### PR DESCRIPTION
Closes #270

## Problem

`webapp/src/compiler.ts` imports directly from the main source tree using deep relative paths:

```typescript
import { parse, parseExpression, ... } from "../../src/compiler/parser.ts";
import { generateSolidity, ... } from "../../src/compiler/codegen.ts";
```

This couples the webapp build to the monorepo directory structure. If the compiler source files move or are reorganized, the webapp breaks.

## Suggested Fix

Options:
1. **Use the published package exports** — import from `skittles` instead of relative paths (requires ensuring the compiler API is properly exported from `src/exports.ts`)
2. **Use a TypeScript path alias** — configure Vite/tsconfig to map `@skittles/compiler` to the source directory
3. **At minimum**, add a comment explaining the coupling and why it exists