### PR TITLE
Cleanup: Regex /extends\s+(\w+)/g duplicated in compiler.ts and resolver.ts [XS]

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -15,6 +15,7 @@ import type {
   StateMutability,
 } from "../types/index.ts";
 import { findTypeScriptFiles, readFile, writeFile } from "../utils/file.ts";
+import { findExtendsReferences } from "../utils/regex.ts";
 import { logInfo, logSuccess, logError, logWarning } from "../utils/console.ts";
 import { parse, collectTypes, collectFunctions, collectClassNames } from "./parser.ts";
 import { generateSolidity, generateSolidityFile, buildSourceMap } from "./codegen.ts";
@@ -170,10 +171,9 @@ export async function compile(
   const stdlibClassNames = getStdlibClassNames();
   const referencedStdlib = new Set<string>();
   for (const source of userSources.values()) {
-    const matches = source.matchAll(/extends\s+(\w+)/g);
-    for (const m of matches) {
-      if (stdlibClassNames.has(m[1]) && !contractOriginFile.has(m[1])) {
-        referencedStdlib.add(m[1]);
+    for (const name of findExtendsReferences(source)) {
+      if (stdlibClassNames.has(name) && !contractOriginFile.has(name)) {
+        referencedStdlib.add(name);
       }
     }
   }
@@ -243,11 +243,10 @@ export async function compile(
     allSourceHashes.set(filePath, hashString(source));
 
     const parents: string[] = [];
-    const extMatches = source.matchAll(/extends\s+(\w+)/g);
-    for (const m of extMatches) {
-      const parentBase = contractOriginFile.get(m[1]);
+    for (const name of findExtendsReferences(source)) {
+      const parentBase = contractOriginFile.get(name);
       if (parentBase && parentBase !== baseName) {
-        parents.push(m[1]);
+        parents.push(name);
       }
     }
     fileExtendsParents.set(filePath, parents);

--- a/src/stdlib/resolver.ts
+++ b/src/stdlib/resolver.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { findExtendsReferences } from "../utils/regex.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const STDLIB_CONTRACTS_DIR = path.resolve(__dirname, "../../stdlib/contracts");
@@ -64,13 +65,9 @@ export function resolveStdlibFiles(referencedClasses: Set<string>): string[] {
     needed.add(entry.filePath);
 
     const source = fs.readFileSync(entry.filePath, "utf-8");
-    const extendsMatch = source.match(/extends\s+(\w+)/g);
-    if (extendsMatch) {
-      for (const m of extendsMatch) {
-        const parent = m.replace(/^extends\s+/, "");
-        const parentEntry = registry.find((e) => e.className === parent);
-        if (parentEntry && !needed.has(parentEntry.filePath)) queue.push(parent);
-      }
+    for (const parent of findExtendsReferences(source)) {
+      const parentEntry = registry.find((e) => e.className === parent);
+      if (parentEntry && !needed.has(parentEntry.filePath)) queue.push(parent);
     }
   }
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,6 @@
+/**
+ * Extract class names referenced in `extends` clauses from source code.
+ */
+export function findExtendsReferences(source: string): string[] {
+  return [...source.matchAll(/extends\s+(\w+)/g)].map((m) => m[1]);
+}

--- a/test/utils/regex.test.ts
+++ b/test/utils/regex.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { findExtendsReferences } from "../../src/utils/regex";
+
+describe("findExtendsReferences", () => {
+  it("should extract a single extends reference", () => {
+    const source = "class MyToken extends ERC20 {}";
+    expect(findExtendsReferences(source)).toEqual(["ERC20"]);
+  });
+
+  it("should extract multiple extends references", () => {
+    const source = `
+      class MyToken extends ERC20 {}
+      class MyNFT extends ERC721 {}
+    `;
+    expect(findExtendsReferences(source)).toEqual(["ERC20", "ERC721"]);
+  });
+
+  it("should return an empty array when there are no extends clauses", () => {
+    const source = "class MyContract {}";
+    expect(findExtendsReferences(source)).toEqual([]);
+  });
+
+  it("should handle extra whitespace between extends and class name", () => {
+    const source = "class MyToken extends   ERC20 {}";
+    expect(findExtendsReferences(source)).toEqual(["ERC20"]);
+  });
+
+  it("should handle empty source", () => {
+    expect(findExtendsReferences("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #272

## Problem

The regex pattern `/extends\s+(\w+)/g` for detecting class inheritance is used in multiple places:

- `src/compiler/compiler.ts` line 166: scanning user sources for stdlib references
- `src/compiler/compiler.ts` line 238: building dependency maps
- `src/stdlib/resolver.ts` line 66: building the stdlib registry

Each usage creates its own regex literal. This is a minor DRY violation, but more importantly, if the pattern ever needs to change (e.g. to handle `extends A, B` or multiline extends), it would need to be updated in three places.

## Suggested Fix

Extract a shared utility:

```typescript
export function findExtendsReferences(source: string): string[] {
  return [...source.matchAll(/extends\s+(\w+)/g)].map(m => m[1]);
}
```

Place this in `src/utils/` or `src/compiler/` and use it everywhere.