### PR TITLE
Cleanup: Invalidate stdlib registry cache in resolver.ts [XS]

### DIFF
--- a/src/stdlib/resolver.ts
+++ b/src/stdlib/resolver.ts
@@ -11,6 +11,12 @@ interface StdlibEntry {
   filePath: string;
 }
 
+/**
+ * Cached registry of stdlib entries. Once built, the cache persists for the
+ * lifetime of the process. Use {@link clearStdlibRegistryCache} or pass
+ * `force: true` to {@link getRegistry} to invalidate it (useful in tests or
+ * development when stdlib files may change between invocations).
+ */
 let _registry: StdlibEntry[] | null = null;
 
 function buildRegistry(): StdlibEntry[] {
@@ -36,9 +42,19 @@ function buildRegistry(): StdlibEntry[] {
   return entries;
 }
 
-function getRegistry(): StdlibEntry[] {
-  if (!_registry) _registry = buildRegistry();
+function getRegistry(force = false): StdlibEntry[] {
+  if (force || !_registry) _registry = buildRegistry();
   return _registry;
+}
+
+/**
+ * Invalidate the cached stdlib registry so the next call to
+ * {@link getStdlibClassNames} or {@link resolveStdlibFiles} rebuilds it
+ * from disk. This is useful in tests or during development when stdlib
+ * files may be added, removed, or modified between invocations.
+ */
+export function clearStdlibRegistryCache(): void {
+  _registry = null;
 }
 
 /**

--- a/test/utils/resolver.test.ts
+++ b/test/utils/resolver.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getStdlibClassNames,
+  clearStdlibRegistryCache,
+} from "../../src/stdlib/resolver";
+
+describe("stdlib resolver cache", () => {
+  beforeEach(() => {
+    clearStdlibRegistryCache();
+  });
+
+  it("returns a non-empty set of class names", () => {
+    const names = getStdlibClassNames();
+    expect(names.size).toBeGreaterThan(0);
+    expect(names.has("ERC20")).toBe(true);
+  });
+
+  it("returns the same results after clearing and rebuilding the cache", () => {
+    const first = getStdlibClassNames();
+    clearStdlibRegistryCache();
+    const second = getStdlibClassNames();
+    expect(second).toEqual(first);
+  });
+
+  it("clearStdlibRegistryCache forces a fresh scan on next access", () => {
+    // Access once to populate cache
+    const before = getStdlibClassNames();
+    expect(before.size).toBeGreaterThan(0);
+
+    // Clear and re-fetch — should still work correctly
+    clearStdlibRegistryCache();
+    const after = getStdlibClassNames();
+    expect(after.size).toBeGreaterThan(0);
+    expect(after).toEqual(before);
+  });
+});


### PR DESCRIPTION
Closes #267

## Problem

`src/stdlib/resolver.ts` caches the stdlib registry in a module-level `_registry` variable (line 13). Once built, the cache is never invalidated, even if the stdlib directory contents change. This can cause stale results during development or testing when stdlib files are modified.

Additionally, `buildRegistry()` uses `fs.readFileSync` in a loop (line 65) which is fine for a one-time scan but could be slow if the stdlib grows significantly.

## Suggested Fix

Either:
1. Accept a `force` parameter to rebuild the cache when needed
2. Or check file modification times against the cached version
3. At minimum, document the caching behavior so test authors know to account for it