### PR TITLE
Refactor: Extract duplicated syntax highlighting into shared module in webapp [S]

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, createContext, useContext, lazy, Suspense } from "
 import { Zap, Shuffle, Code, Shield, Layers, Timer } from "lucide-react";
 import "./App.css";
 import { URLS } from "./constants.ts";
+import { type Token, highlightTS, highlightSol } from "./syntax-highlight.ts";
 
 const Playground = lazy(() => import("./Playground.tsx"));
 
@@ -70,99 +71,6 @@ function HeroBadge() {
   );
 }
 
-type Token = { text: string; type: "keyword" | "string" | "type" | "comment" | "number" | "plain" | "punctuation" };
-
-function highlightTS(line: string): Token[] {
-  const tokens: Token[] = [];
-  const keywords = /\b(import|from|export|class|private|constructor|if|throw|new|return|this|const|let|var|function|extends|implements)\b/g;
-  const types = /\b(string|number|boolean|void|address|Record|Map|Error|Indexed)\b/g;
-  const strings = /"[^"]*"|'[^']*'/g;
-  const numbers = /\b\d+\b/g;
-  const comments = /\/\/.*/g;
-
-  const spans: { start: number; end: number; type: Token["type"] }[] = [];
-
-  for (const r of [
-    { regex: comments, type: "comment" as const },
-    { regex: strings, type: "string" as const },
-    { regex: keywords, type: "keyword" as const },
-    { regex: types, type: "type" as const },
-    { regex: numbers, type: "number" as const },
-  ]) {
-    let m;
-    while ((m = r.regex.exec(line)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
-    }
-  }
-
-  spans.sort((a, b) => a.start - b.start);
-
-  const merged: typeof spans = [];
-  for (const s of spans) {
-    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
-    merged.push(s);
-  }
-
-  let cursor = 0;
-  for (const s of merged) {
-    if (cursor < s.start) {
-      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
-    }
-    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
-    cursor = s.end;
-  }
-  if (cursor < line.length) {
-    tokens.push({ text: line.slice(cursor), type: "plain" });
-  }
-
-  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
-}
-
-function highlightSol(line: string): Token[] {
-  const tokens: Token[] = [];
-  const keywords = /\b(pragma|solidity|contract|function|constructor|mapping|public|internal|virtual|view|returns|require|return|event|emit|modifier|memory|storage|calldata|payable|external|pure|indexed)\b/g;
-  const types = /\b(uint256|address|bool|string|bytes|bytes32|int256)\b/g;
-  const strings = /"[^"]*"|'[^']*'/g;
-  const numbers = /\b\d+(\.\d+)?\b/g;
-  const comments = /\/\/.*/g;
-
-  const spans: { start: number; end: number; type: Token["type"] }[] = [];
-
-  for (const r of [
-    { regex: comments, type: "comment" as const },
-    { regex: strings, type: "string" as const },
-    { regex: keywords, type: "keyword" as const },
-    { regex: types, type: "type" as const },
-    { regex: numbers, type: "number" as const },
-  ]) {
-    let m;
-    while ((m = r.regex.exec(line)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
-    }
-  }
-
-  spans.sort((a, b) => a.start - b.start);
-
-  const merged: typeof spans = [];
-  for (const s of spans) {
-    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
-    merged.push(s);
-  }
-
-  let cursor = 0;
-  for (const s of merged) {
-    if (cursor < s.start) {
-      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
-    }
-    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
-    cursor = s.end;
-  }
-  if (cursor < line.length) {
-    tokens.push({ text: line.slice(cursor), type: "plain" });
-  }
-
-  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
-}
 
 function SyntaxLine({ line, lang }: { line: string; lang: "ts" | "sol" }) {
   if (!line.trim()) return <div className="code-line">{"\u00A0"}</div>;

--- a/webapp/src/Playground.tsx
+++ b/webapp/src/Playground.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect, type ChangeEvent } from "react";
 import { compileSource } from "./compiler.ts";
 import "./Playground.css";
+import { highlightTS, highlightSol } from "./syntax-highlight.ts";
 
 const EXAMPLES: Record<string, string> = {
   Token: `import { address, msg } from "skittles";
@@ -119,54 +120,6 @@ function getInitialSource(): string {
   return EXAMPLES[DEFAULT_EXAMPLE];
 }
 
-type Token = { text: string; type: "keyword" | "string" | "type" | "comment" | "number" | "plain" };
-
-function highlightSol(line: string): Token[] {
-  const tokens: Token[] = [];
-  const keywords = /\b(pragma|solidity|contract|function|constructor|mapping|public|internal|virtual|view|returns|require|return|event|emit|modifier|memory|storage|calldata|payable|external|pure|indexed)\b/g;
-  const types = /\b(uint256|address|bool|string|bytes|bytes32|int256)\b/g;
-  const strings = /"[^"]*"|'[^']*'/g;
-  const numbers = /\b\d+(\.\d+)?\b/g;
-  const comments = /\/\/.*/g;
-
-  const spans: { start: number; end: number; type: Token["type"] }[] = [];
-
-  for (const r of [
-    { regex: comments, type: "comment" as const },
-    { regex: strings, type: "string" as const },
-    { regex: keywords, type: "keyword" as const },
-    { regex: types, type: "type" as const },
-    { regex: numbers, type: "number" as const },
-  ]) {
-    let m;
-    while ((m = r.regex.exec(line)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
-    }
-  }
-
-  spans.sort((a, b) => a.start - b.start);
-
-  const merged: typeof spans = [];
-  for (const s of spans) {
-    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
-    merged.push(s);
-  }
-
-  let cursor = 0;
-  for (const s of merged) {
-    if (cursor < s.start) {
-      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
-    }
-    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
-    cursor = s.end;
-  }
-  if (cursor < line.length) {
-    tokens.push({ text: line.slice(cursor), type: "plain" });
-  }
-
-  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
-}
-
 function SolLine({ line }: { line: string }) {
   if (!line.trim()) return <div className="pg-code-line">{"\u00A0"}</div>;
   const tokens = highlightSol(line);
@@ -177,52 +130,6 @@ function SolLine({ line }: { line: string }) {
       ))}
     </div>
   );
-}
-
-function highlightTS(line: string): Token[] {
-  const tokens: Token[] = [];
-  const keywords = /\b(import|from|export|class|private|constructor|if|throw|new|return|this|const|let|var|function|extends|implements)\b/g;
-  const types = /\b(string|number|boolean|void|address|Record|Map|Error|Indexed)\b/g;
-  const strings = /"[^"]*"|'[^']*'/g;
-  const numbers = /\b\d+\b/g;
-  const comments = /\/\/.*/g;
-
-  const spans: { start: number; end: number; type: Token["type"] }[] = [];
-
-  for (const r of [
-    { regex: comments, type: "comment" as const },
-    { regex: strings, type: "string" as const },
-    { regex: keywords, type: "keyword" as const },
-    { regex: types, type: "type" as const },
-    { regex: numbers, type: "number" as const },
-  ]) {
-    let m;
-    while ((m = r.regex.exec(line)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
-    }
-  }
-
-  spans.sort((a, b) => a.start - b.start);
-
-  const merged: typeof spans = [];
-  for (const s of spans) {
-    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
-    merged.push(s);
-  }
-
-  let cursor = 0;
-  for (const s of merged) {
-    if (cursor < s.start) {
-      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
-    }
-    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
-    cursor = s.end;
-  }
-  if (cursor < line.length) {
-    tokens.push({ text: line.slice(cursor), type: "plain" });
-  }
-
-  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
 }
 
 function TSLine({ line }: { line: string }) {

--- a/webapp/src/syntax-highlight.ts
+++ b/webapp/src/syntax-highlight.ts
@@ -1,0 +1,93 @@
+export type Token = { text: string; type: "keyword" | "string" | "type" | "comment" | "number" | "plain" | "punctuation" };
+
+export function highlightTS(line: string): Token[] {
+  const tokens: Token[] = [];
+  const keywords = /\b(import|from|export|class|private|constructor|if|throw|new|return|this|const|let|var|function|extends|implements)\b/g;
+  const types = /\b(string|number|boolean|void|address|Record|Map|Error|Indexed)\b/g;
+  const strings = /"[^"]*"|'[^']*'/g;
+  const numbers = /\b\d+\b/g;
+  const comments = /\/\/.*/g;
+
+  const spans: { start: number; end: number; type: Token["type"] }[] = [];
+
+  for (const r of [
+    { regex: comments, type: "comment" as const },
+    { regex: strings, type: "string" as const },
+    { regex: keywords, type: "keyword" as const },
+    { regex: types, type: "type" as const },
+    { regex: numbers, type: "number" as const },
+  ]) {
+    let m;
+    while ((m = r.regex.exec(line)) !== null) {
+      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
+    }
+  }
+
+  spans.sort((a, b) => a.start - b.start);
+
+  const merged: typeof spans = [];
+  for (const s of spans) {
+    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
+    merged.push(s);
+  }
+
+  let cursor = 0;
+  for (const s of merged) {
+    if (cursor < s.start) {
+      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
+    }
+    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
+    cursor = s.end;
+  }
+  if (cursor < line.length) {
+    tokens.push({ text: line.slice(cursor), type: "plain" });
+  }
+
+  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
+}
+
+export function highlightSol(line: string): Token[] {
+  const tokens: Token[] = [];
+  const keywords = /\b(pragma|solidity|contract|function|constructor|mapping|public|internal|virtual|view|returns|require|return|event|emit|modifier|memory|storage|calldata|payable|external|pure|indexed)\b/g;
+  const types = /\b(uint256|address|bool|string|bytes|bytes32|int256)\b/g;
+  const strings = /"[^"]*"|'[^']*'/g;
+  const numbers = /\b\d+(\.\d+)?\b/g;
+  const comments = /\/\/.*/g;
+
+  const spans: { start: number; end: number; type: Token["type"] }[] = [];
+
+  for (const r of [
+    { regex: comments, type: "comment" as const },
+    { regex: strings, type: "string" as const },
+    { regex: keywords, type: "keyword" as const },
+    { regex: types, type: "type" as const },
+    { regex: numbers, type: "number" as const },
+  ]) {
+    let m;
+    while ((m = r.regex.exec(line)) !== null) {
+      spans.push({ start: m.index, end: m.index + m[0].length, type: r.type });
+    }
+  }
+
+  spans.sort((a, b) => a.start - b.start);
+
+  const merged: typeof spans = [];
+  for (const s of spans) {
+    if (merged.length > 0 && s.start < merged[merged.length - 1].end) continue;
+    merged.push(s);
+  }
+
+  let cursor = 0;
+  for (const s of merged) {
+    if (cursor < s.start) {
+      tokens.push({ text: line.slice(cursor, s.start), type: "plain" });
+    }
+    tokens.push({ text: line.slice(s.start, s.end), type: s.type });
+    cursor = s.end;
+  }
+  if (cursor < line.length) {
+    tokens.push({ text: line.slice(cursor), type: "plain" });
+  }
+
+  return tokens.length > 0 ? tokens : [{ text: line, type: "plain" }];
+}


### PR DESCRIPTION
Closes #259

## Problem

The webapp has two completely duplicated implementations of syntax highlighting:

- `App.tsx` contains `highlightTS()` and `highlightSol()` (lines ~73–163)
- `Playground.tsx` contains its own `highlightSol()` and `highlightTS()` (lines ~123–222)

These are functionally identical implementations with the same regex patterns, color mappings, and token processing logic. Additionally, the `Token` type (with `type` and `value` fields) is defined independently in both files.

## Suggested Fix

Create a shared `webapp/src/syntax-highlight.ts` module:

```typescript
export interface Token { type: string; value: string; }
export function highlightTS(code: string): Token[][] { ... }
export function highlightSol(code: string): Token[][] { ... }
```

Import from both `App.tsx` and `Playground.tsx`.