### PR TITLE
Cleanup: Replace hardcoded colors with CSS custom properties in webapp [M]

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -83,7 +83,7 @@
   gap: 8px;
   padding: 8px 16px;
   border-radius: 100px;
-  border: 1px solid #22D3EE30;
+  border: 1px solid var(--accent-translucent);
 }
 
 .badge-dot {
@@ -95,7 +95,7 @@
 
 .badge-text {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: 500;
   color: var(--accent);
 }
@@ -208,20 +208,20 @@
 }
 
 .dot-red {
-  background-color: #EF4444;
+  background-color: var(--color-error);
 }
 
 .dot-yellow {
-  background-color: #F59E0B;
+  background-color: var(--color-warning);
 }
 
 .dot-green {
-  background-color: #22C55E;
+  background-color: var(--color-success);
 }
 
 .code-filename {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: 500;
   color: var(--text-tertiary);
 }
@@ -232,7 +232,7 @@
 
 .code-line {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   line-height: 1.8;
   white-space: pre;
   color: var(--text-secondary);
@@ -243,7 +243,7 @@
 }
 
 .tok-string {
-  color: #A5D6A7;
+  color: var(--color-syntax-string);
 }
 
 .tok-type {
@@ -256,7 +256,7 @@
 }
 
 .tok-number {
-  color: #F9A8D4;
+  color: var(--color-syntax-number);
 }
 
 .tok-plain {
@@ -398,7 +398,7 @@
 }
 
 .comparison-panel--highlighted {
-  border-color: #22D3EE30;
+  border-color: var(--accent-translucent);
 }
 
 .comparison-header {
@@ -537,7 +537,7 @@
 
 .terminal-comment {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: normal;
   color: var(--text-muted);
 }
@@ -550,9 +550,9 @@
 
 .terminal-success {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: normal;
-  color: #22C55E;
+  color: var(--color-success);
 }
 
 /* ==================== Final CTA ==================== */

--- a/webapp/src/Playground.css
+++ b/webapp/src/Playground.css
@@ -45,7 +45,7 @@
 
 .pg-select {
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: 500;
   color: var(--text-primary);
   background-color: var(--bg-surface);
@@ -68,7 +68,7 @@
 
 .pg-share-btn {
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   font-weight: 600;
   color: var(--text-inverted);
   background-color: var(--accent);
@@ -142,7 +142,7 @@
   padding: 20px;
   background-color: var(--bg-inset);
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   line-height: 1.8;
   white-space: pre;
   overflow: auto;
@@ -159,7 +159,7 @@
   color: transparent;
   caret-color: var(--text-primary);
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   line-height: 1.8;
   border: none;
   outline: 2px solid transparent;
@@ -189,7 +189,7 @@
 
 .pg-code-line {
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   line-height: 1.8;
   white-space: pre;
   color: var(--text-secondary);
@@ -198,9 +198,9 @@
 /* ==================== Error ==================== */
 .pg-error {
   font-family: "JetBrains Mono", monospace;
-  font-size: 13px;
+  font-size: var(--font-size-code);
   line-height: 1.6;
-  color: #ef4444;
+  color: var(--color-error);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,5 +1,6 @@
 :root {
   --accent: #22D3EE;
+  --accent-translucent: #22D3EE30;
   --bg-inset: #0F172A;
   --bg-primary: #0A0F1C;
   --bg-surface: #1E293B;
@@ -9,6 +10,15 @@
   --text-secondary: #94A3B8;
   --text-tertiary: #64748B;
   --border: #1E293B;
+  --color-error: #EF4444;
+  --color-warning: #F59E0B;
+  --color-success: #22C55E;
+  --color-syntax-string: #A5D6A7;
+  --color-syntax-number: #F9A8D4;
+  --font-size-code: 13px;
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
 }
 
 *,


### PR DESCRIPTION
Closes #261

## Problem

The webapp CSS files use many hardcoded color values instead of CSS custom properties:

### App.css (643 lines)
- `#EF4444`, `#F59E0B`, `#22C55E` (window dots)
- `#22D3EE30`, `#A5D6A7`, `#F9A8D4` (accent colors)
- Various background, text, and border colors repeated throughout

### Playground.css (223 lines)
- `#ef4444` for error styling
- Various background colors

### Cross-file issues
- Breakpoint values `768px`, `1024px`, `640px` are duplicated across both CSS files without shared variables
- Code font size `13px` is repeated in multiple places

## Suggested Fix

Define a design token system in `index.css` using CSS custom properties:

```css
:root {
  --color-error: #ef4444;
  --color-warning: #f59e0b;
  --color-success: #22c55e;
  --color-accent: #22d3ee;
  --font-size-code: 13px;
  --breakpoint-sm: 640px;
  --breakpoint-md: 768px;
  --breakpoint-lg: 1024px;
}
```

Reference these variables throughout App.css and Playground.css.