### PR TITLE
Cleanup: Add Indexed to Pausable event parameters for consistency [XS]

### DIFF
--- a/stdlib/contracts/security/Pausable.ts
+++ b/stdlib/contracts/security/Pausable.ts
@@ -1,4 +1,4 @@
-import { address, msg, SkittlesEvent, SkittlesError } from "skittles";
+import { address, Indexed, msg, SkittlesEvent, SkittlesError } from "skittles";
 
 /**
  * Contract module that allows children to implement an emergency stop
@@ -10,8 +10,8 @@ import { address, msg, SkittlesEvent, SkittlesError } from "skittles";
  * of functions that need the check.
  */
 export class Pausable {
-  Paused: SkittlesEvent<{ account: address }>;
-  Unpaused: SkittlesEvent<{ account: address }>;
+  Paused: SkittlesEvent<{ account: Indexed<address> }>;
+  Unpaused: SkittlesEvent<{ account: Indexed<address> }>;
 
   EnforcedPause: SkittlesError<{}>;
   ExpectedPause: SkittlesError<{}>;


### PR DESCRIPTION
Closes #254

## Problem

In `stdlib/contracts/security/Pausable.ts`, the `Paused` and `Unpaused` events do not mark `account` as `Indexed`:

```typescript
Paused: SkittlesEvent<{ account: address }>;
Unpaused: SkittlesEvent<{ account: address }>;
```

Meanwhile, all other stdlib events that include an `address` parameter use `Indexed`:
- `Ownable.ts` — `OwnershipTransferred` uses `Indexed<address>`
- `ERC20.ts` — `Transfer` and `Approval` use `Indexed<address>`
- `AccessControl.ts` — `RoleGranted` etc. use `Indexed<address>`

## Suggested Fix

```typescript
Paused: SkittlesEvent<{ account: Indexed<address> }>;
Unpaused: SkittlesEvent<{ account: Indexed<address> }>;
```

This allows filtering pause/unpause events by the account that triggered them.