### PR TITLE
Cleanup: defaultConfig duplicated in cache.test.ts vs fixtures.ts [XS]

### DIFF
--- a/test/compiler/cache.test.ts
+++ b/test/compiler/cache.test.ts
@@ -5,18 +5,14 @@ import path from "path";
 import { compile } from "../../src/compiler/compiler";
 import type { SkittlesConfig } from "../../src/types";
 import * as parserModule from "../../src/compiler/parser";
+import { defaultConfig as baseDefaultConfig } from "../fixtures.js";
 
 const pkgJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8")
 );
 
 const defaultConfig: Required<SkittlesConfig> = {
-  typeCheck: true,
-  optimizer: { enabled: false, runs: 200 },
-  contractsDir: "contracts",
-  outputDir: "artifacts",
-  cacheDir: "cache",
-  consoleLog: false,
+  ...baseDefaultConfig,
   solidity: { version: "^0.8.20", license: "MIT" },
 };
 


### PR DESCRIPTION
Closes #258

## Problem

`test/fixtures.ts` exports a `defaultConfig` object used across the test suite. However, `test/compiler/cache.test.ts` (lines 13–21) defines its own `defaultConfig` with an additional `solidity` field instead of importing and extending the shared one.

## Suggested Fix

Import `defaultConfig` from `test/fixtures.ts` and spread it:

```typescript
import { defaultConfig } from "../fixtures.js";

const cacheTestConfig = {
  ...defaultConfig,
  solidity: { version: "0.8.28" },
};
```

This prevents the two configs from drifting apart.