### PR TITLE
Refactor: Extract shared test utilities for temp dirs, event parsing, and env setup [M]

### DIFF
--- a/test/behavioral/erc20.test.ts
+++ b/test/behavioral/erc20.test.ts
@@ -3,6 +3,7 @@ import {
   createTestEnv,
   compileAndDeploy,
   connectAs,
+  getEventFromReceipt,
   TestEnv,
   DeployedContract,
 } from "./helpers";
@@ -165,16 +166,7 @@ describe("ERC20 behavioral tests", () => {
       const tx = await token.contract.transfer(aliceAddr, amount);
       const receipt = await tx.wait();
 
-      const iface = new ethers.Interface(token.abi);
-      const transferEvent = receipt.logs
-        .map((log: ethers.Log) => {
-          try {
-            return iface.parseLog(log);
-          } catch {
-            return null;
-          }
-        })
-        .find((e: ethers.LogDescription | null) => e?.name === "Transfer");
+      const transferEvent = getEventFromReceipt(receipt, token.abi, "Transfer");
 
       expect(transferEvent).toBeDefined();
       expect(transferEvent!.args[0]).toBe(deployerAddr);
@@ -208,16 +200,7 @@ describe("ERC20 behavioral tests", () => {
       const tx = await token.contract.approve(bobAddr, amount);
       const receipt = await tx.wait();
 
-      const iface = new ethers.Interface(token.abi);
-      const approvalEvent = receipt.logs
-        .map((log: ethers.Log) => {
-          try {
-            return iface.parseLog(log);
-          } catch {
-            return null;
-          }
-        })
-        .find((e: ethers.LogDescription | null) => e?.name === "Approval");
+      const approvalEvent = getEventFromReceipt(receipt, token.abi, "Approval");
 
       expect(approvalEvent).toBeDefined();
       expect(approvalEvent!.args[0]).toBe(deployerAddr);
@@ -311,16 +294,7 @@ describe("ERC20 behavioral tests", () => {
       const tx = await aliceToken.transferFrom(deployerAddr, bobAddr, amount);
       const receipt = await tx.wait();
 
-      const iface = new ethers.Interface(token.abi);
-      const transferEvent = receipt.logs
-        .map((log: ethers.Log) => {
-          try {
-            return iface.parseLog(log);
-          } catch {
-            return null;
-          }
-        })
-        .find((e: ethers.LogDescription | null) => e?.name === "Transfer");
+      const transferEvent = getEventFromReceipt(receipt, token.abi, "Transfer");
 
       expect(transferEvent).toBeDefined();
       expect(transferEvent!.args[0]).toBe(deployerAddr);

--- a/test/behavioral/helpers.ts
+++ b/test/behavioral/helpers.ts
@@ -106,3 +106,26 @@ export function connectAs(
 ): ethers.Contract {
   return new ethers.Contract(deployed.address, deployed.abi, signer);
 }
+
+/**
+ * Parse a named event from a transaction receipt using the contract ABI.
+ * Returns the parsed log description, or `undefined` if the event is not found.
+ */
+export function getEventFromReceipt(
+  receipt: ethers.TransactionReceipt,
+  abi: ethers.InterfaceAbi,
+  eventName: string
+): ethers.LogDescription | undefined {
+  const iface = new ethers.Interface(abi);
+  return receipt.logs
+    .map((log: ethers.Log) => {
+      try {
+        return iface.parseLog(log);
+      } catch {
+        return null;
+      }
+    })
+    .find(
+      (e: ethers.LogDescription | null) => e?.name === eventName
+    ) as ethers.LogDescription | undefined;
+}

--- a/test/behavioral/stdlib.test.ts
+++ b/test/behavioral/stdlib.test.ts
@@ -3,6 +3,7 @@ import {
   createTestEnv,
   compileAndDeploy,
   connectAs,
+  getEventFromReceipt,
   TestEnv,
   DeployedContract,
 } from "./helpers";
@@ -134,16 +135,7 @@ class MyToken extends ERC20 {
       const amount = 50n;
       const tx = await token.contract.transfer(aliceAddr, amount);
       const receipt = await tx.wait();
-      const iface = new ethers.Interface(token.abi);
-      const log = receipt.logs
-        .map((l: ethers.Log) => {
-          try {
-            return iface.parseLog(l);
-          } catch {
-            return null;
-          }
-        })
-        .find((e: ethers.LogDescription | null) => e?.name === "Transfer");
+      const log = getEventFromReceipt(receipt, token.abi, "Transfer");
       expect(log).toBeDefined();
       expect(log!.args[0]).toBe(deployerAddr);
       expect(log!.args[1]).toBe(aliceAddr);
@@ -172,16 +164,7 @@ class MyToken extends ERC20 {
     it("emits Approval event", async () => {
       const tx = await token.contract.approve(bobAddr, 200n);
       const receipt = await tx.wait();
-      const iface = new ethers.Interface(token.abi);
-      const log = receipt.logs
-        .map((l: ethers.Log) => {
-          try {
-            return iface.parseLog(l);
-          } catch {
-            return null;
-          }
-        })
-        .find((e: ethers.LogDescription | null) => e?.name === "Approval");
+      const log = getEventFromReceipt(receipt, token.abi, "Approval");
       expect(log).toBeDefined();
     });
 

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -1,22 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 import { cleanCommand } from "../../src/commands/clean";
+import { useTempDir } from "../fixtures";
 
-const TEST_DIR = path.join(__dirname, "__test_tmp_clean__");
-
-beforeEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-  fs.mkdirSync(TEST_DIR, { recursive: true });
-});
-
-afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-});
+const TEST_DIR = useTempDir(__dirname, "__test_tmp_clean__");
 
 describe("cleanCommand", () => {
   it("should remove the default output directory and cache directory", async () => {

--- a/test/commands/compile.test.ts
+++ b/test/commands/compile.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import { compileCommand, watchCompile } from "../../src/commands/compile";
+import { useTempDir } from "../fixtures";
 
-const TEST_DIR = path.join(__dirname, "__test_tmp_compile__");
+const TEST_DIR = useTempDir(__dirname, "__test_tmp_compile__");
 
 const SIMPLE_CONTRACT = `export class Counter {
   count: number = 0;
@@ -18,19 +19,6 @@ const MODIFIED_CONTRACT = `export class Counter {
     this.count += 2;
   }
 }`;
-
-beforeEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-  fs.mkdirSync(TEST_DIR, { recursive: true });
-});
-
-afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-});
 
 describe("compileCommand", () => {
   it("should compile contracts successfully", async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,26 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import { initCommand } from "../../src/commands/init";
+import { useTempDir } from "../fixtures";
 
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
 }));
 
-const TEST_DIR = path.join(__dirname, "__test_tmp_init__");
-
-beforeEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-  fs.mkdirSync(TEST_DIR, { recursive: true });
-});
-
-afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-});
+const TEST_DIR = useTempDir(__dirname, "__test_tmp_init__");
 
 describe("initCommand", () => {
   it("should create contracts directory", async () => {

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,22 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 import { loadConfig, DEFAULT_CONFIG } from "../../src/config/config";
+import { useTempDir } from "../fixtures";
 
-const TEST_DIR = path.join(__dirname, "__test_tmp_config__");
-
-beforeEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-  fs.mkdirSync(TEST_DIR, { recursive: true });
-});
-
-afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-});
+const TEST_DIR = useTempDir(__dirname, "__test_tmp_config__");
 
 describe("loadConfig", () => {
   it("should return defaults when no config file exists", async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,3 +1,6 @@
+import { beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
 import type { SkittlesConfig } from "../src/types";
 
 export const defaultConfig: Required<SkittlesConfig> = {
@@ -8,3 +11,30 @@ export const defaultConfig: Required<SkittlesConfig> = {
   cacheDir: "cache",
   consoleLog: false,
 };
+
+/**
+ * Register beforeEach/afterEach hooks that create and clean up a temporary
+ * directory scoped to the calling test file.
+ *
+ * @param baseDir  The directory that will contain the temp folder (typically `__dirname`).
+ * @param name     A unique name for the temp folder (default `"__test_tmp__"`).
+ * @returns The absolute path to the temporary directory.
+ */
+export function useTempDir(baseDir: string, name = "__test_tmp__"): string {
+  const dir = path.join(baseDir, name);
+
+  beforeEach(() => {
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  return dir;
+}

--- a/test/utils/file.test.ts
+++ b/test/utils/file.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 import {
@@ -8,21 +8,9 @@ import {
   removeDirectory,
   ensureDirectory,
 } from "../../src/utils/file";
+import { useTempDir } from "../fixtures";
 
-const TEST_DIR = path.join(__dirname, "__test_tmp__");
-
-beforeEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-  fs.mkdirSync(TEST_DIR, { recursive: true });
-});
-
-afterEach(() => {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
-  }
-});
+const TEST_DIR = useTempDir(__dirname);
 
 describe("findTypeScriptFiles", () => {
   it("should find .ts files in a directory", () => {


### PR DESCRIPTION
Closes #255

## Problem

The test suite has several repeated patterns that should be centralized:

### 1. Temp directory lifecycle (5 files)
The exact same beforeEach/afterEach pattern for creating and cleaning up temp directories appears in:
- `test/utils/file.test.ts`
- `test/config/config.test.ts`
- `test/commands/compile.test.ts`
- `test/commands/init.test.ts`
- `test/commands/clean.test.ts`

```typescript
beforeEach(() => {
  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
  fs.mkdirSync(TEST_DIR, { recursive: true });
});
afterEach(() => {
  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
});
```

### 2. Event parsing (6+ uses)
The same 4-line pattern for parsing events from transaction receipts appears across `stdlib.test.ts` and `erc20.test.ts`:
```typescript
const iface = new ethers.Interface(token.abi);
const log = receipt.logs
  .map((l) => { try { return iface.parseLog(l); } catch { return null; } })
  .find((e) => e?.name === "Transfer");
```

### 3. Behavioral env setup (8+ describe blocks)
Nearly identical env/deployer/alice/contract setup in every behavioral test suite.

## Suggested Fix

1. Add `createTempDir(name)` / `useTempDir(name)` helper in `test/fixtures.ts`
2. Add `getEventFromReceipt(receipt, abi, eventName)` helper in `test/behavioral/helpers.ts`
3. Consider a `withBehavioralEnv()` wrapper or shared setup fixture for behavioral tests