### PR TITLE
Cleanup: DRY violation between compileCommand and runCompilation in compile.ts [S]

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -5,7 +5,12 @@ import { loadConfig } from "../config/config.ts";
 import { compile } from "../compiler/compiler.ts";
 import { logSuccess, logError, logInfo } from "../utils/console.ts";
 
-export async function compileCommand(projectRoot: string): Promise<void> {
+const DEBOUNCE_MS = 200;
+
+async function executeCompilation(
+  projectRoot: string,
+  options?: { exitOnError?: boolean }
+): Promise<boolean> {
   const spinner = ora({
     text: "Loading configuration...",
     color: "cyan",
@@ -22,20 +27,31 @@ export async function compileCommand(projectRoot: string): Promise<void> {
       logSuccess(
         `${result.artifacts.length} contract(s) compiled successfully`
       );
+      return true;
     } else {
       spinner.fail("Compilation failed");
       for (const error of result.errors) {
         logError(error);
       }
-      process.exit(1);
+      if (options?.exitOnError) {
+        process.exit(1);
+      }
+      return false;
     }
   } catch (err) {
     spinner.fail("Compilation failed");
     const message =
       err instanceof Error ? err.message : "Unknown error occurred";
     logError(message);
-    process.exit(1);
+    if (options?.exitOnError) {
+      process.exit(1);
+    }
+    return false;
   }
+}
+
+export async function compileCommand(projectRoot: string): Promise<void> {
+  await executeCompilation(projectRoot, { exitOnError: true });
 }
 
 export async function watchCompile(projectRoot: string): Promise<() => void> {
@@ -43,7 +59,7 @@ export async function watchCompile(projectRoot: string): Promise<() => void> {
   const contractsDir = path.join(projectRoot, config.contractsDir);
 
   // Run initial compilation
-  await runCompilation(projectRoot);
+  await executeCompilation(projectRoot);
 
   logInfo(`Watching for file changes in ${config.contractsDir}/...`);
 
@@ -62,8 +78,8 @@ export async function watchCompile(projectRoot: string): Promise<() => void> {
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         logInfo(`File changed: ${filename}`);
-        runCompilation(projectRoot);
-      }, 200);
+        void executeCompilation(projectRoot);
+      }, DEBOUNCE_MS);
     }
   );
 
@@ -71,33 +87,4 @@ export async function watchCompile(projectRoot: string): Promise<() => void> {
     if (debounceTimer) clearTimeout(debounceTimer);
     watcher.close();
   };
-}
-
-async function runCompilation(projectRoot: string): Promise<void> {
-  const spinner = ora({
-    text: "Compiling contracts...",
-    color: "cyan",
-  }).start();
-
-  try {
-    const config = await loadConfig(projectRoot);
-    const result = await compile(projectRoot, config);
-
-    if (result.success) {
-      spinner.succeed("Compilation complete");
-      logSuccess(
-        `${result.artifacts.length} contract(s) compiled successfully`
-      );
-    } else {
-      spinner.fail("Compilation failed");
-      for (const error of result.errors) {
-        logError(error);
-      }
-    }
-  } catch (err) {
-    spinner.fail("Compilation failed");
-    const message =
-      err instanceof Error ? err.message : "Unknown error occurred";
-    logError(message);
-  }
 }


### PR DESCRIPTION
Closes #249

## Problem

In `src/commands/compile.ts`, `compileCommand()` (lines 8–35) and `runCompilation()` (lines 68–92) share nearly identical logic:

- Both load config
- Both create a spinner
- Both call `compile()`
- Both handle success/error logging

The only difference is that `compileCommand` calls `process.exit(1)` on failure, while `runCompilation` (used by watch mode) does not.

## Suggested Fix

Extract the shared compilation logic into a single internal function with an option for exit behavior:

```typescript
async function executeCompilation(projectRoot: string, options?: { exitOnError?: boolean }): Promise<boolean> {
  // shared logic
}
```

Both `compileCommand` and `runCompilation` become thin wrappers.

### Additional Issues
- Debounce value `200` (line 59) is a magic number
- `runCompilation` is async but not awaited in the `setTimeout` callback (line 63), which means errors in watch mode could be silently lost