### PR TITLE
Cleanup: Use named constants for ReentrancyGuard status values [XS]

### DIFF
--- a/stdlib/contracts/security/ReentrancyGuard.ts
+++ b/stdlib/contracts/security/ReentrancyGuard.ts
@@ -9,22 +9,25 @@ import { SkittlesError } from "skittles";
  * `this._nonReentrantAfter()` at the end.
  */
 export class ReentrancyGuard {
+  static readonly NOT_ENTERED: number = 1;
+  static readonly ENTERED: number = 2;
+
   ReentrancyGuardReentrantCall: SkittlesError<{}>;
 
-  private _status: number = 1;
+  private _status: number = ReentrancyGuard.NOT_ENTERED;
 
   protected _nonReentrantBefore(): void {
-    if (this._status == 2) {
+    if (this._status == ReentrancyGuard.ENTERED) {
       throw this.ReentrancyGuardReentrantCall();
     }
-    this._status = 2;
+    this._status = ReentrancyGuard.ENTERED;
   }
 
   protected _nonReentrantAfter(): void {
-    this._status = 1;
+    this._status = ReentrancyGuard.NOT_ENTERED;
   }
 
   protected _reentrancyGuardEntered(): boolean {
-    return this._status == 2;
+    return this._status == ReentrancyGuard.ENTERED;
   }
 }


### PR DESCRIPTION
Closes #253

## Problem

In `stdlib/contracts/security/ReentrancyGuard.ts`, the reentrancy status uses magic numbers:

```typescript
_status: number = 1;
// ...
if (this._status == 2) { throw new ReentrancyGuardReentrantCall(); }
this._status = 2;
// ...
this._status = 1;
```

The values `1` and `2` have no obvious meaning without context.

## Suggested Fix

Use `static readonly` constants:

```typescript
static readonly NOT_ENTERED: number = 1;
static readonly ENTERED: number = 2;

_status: number = ReentrancyGuard.NOT_ENTERED;
```

This is consistent with OpenZeppelin's approach and makes the code self-documenting.