### PR TITLE
Cleanup: Add error handling to cleanCommand and CLI entry point [XS]

### DIFF
--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,15 +1,22 @@
 import path from "path";
 import { removeDirectory } from "../utils/file.ts";
-import { logSuccess, logInfo } from "../utils/console.ts";
+import { logSuccess, logInfo, logError } from "../utils/console.ts";
 import { loadConfig } from "../config/config.ts";
 
 export async function cleanCommand(projectRoot: string): Promise<void> {
-  const config = await loadConfig(projectRoot);
-  const outputDir = path.join(projectRoot, config.outputDir);
-  const cacheDir = path.join(projectRoot, config.cacheDir);
-  logInfo(`Removing output directory: ${config.outputDir}/`);
-  removeDirectory(outputDir);
-  logInfo(`Removing cache directory: ${config.cacheDir}/`);
-  removeDirectory(cacheDir);
-  logSuccess("Build artifacts cleaned");
+  try {
+    const config = await loadConfig(projectRoot);
+    const outputDir = path.join(projectRoot, config.outputDir);
+    const cacheDir = path.join(projectRoot, config.cacheDir);
+    logInfo(`Removing output directory: ${config.outputDir}/`);
+    removeDirectory(outputDir);
+    logInfo(`Removing cache directory: ${config.cacheDir}/`);
+    removeDirectory(cacheDir);
+    logSuccess("Build artifacts cleaned");
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Unknown error occurred";
+    logError(message);
+    process.exit(1);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,20 @@ import { hideBin } from "yargs/helpers";
 import { compileCommand, watchCompile } from "./commands/compile.ts";
 import { cleanCommand } from "./commands/clean.ts";
 import { initCommand } from "./commands/init.ts";
-import { printLogo } from "./utils/console.ts";
+import { printLogo, logError } from "./utils/console.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const packageVersion: string = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf-8")
-).version;
+let packageVersion: string;
+try {
+  packageVersion = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf-8")
+  ).version;
+} catch (err) {
+  const message =
+    err instanceof Error ? err.message : "Unknown error occurred";
+  logError(`Failed to read package.json: ${message}`);
+  process.exit(1);
+}
 
 printLogo();
 

--- a/test/commands/clean.test.ts
+++ b/test/commands/clean.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import { cleanCommand } from "../../src/commands/clean";
@@ -39,5 +39,28 @@ describe("cleanCommand", () => {
     await cleanCommand(TEST_DIR);
 
     expect(fs.existsSync(customDir)).toBe(false);
+  });
+
+  it("should log error and exit when config loading fails", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    // Write invalid JSON config to trigger loadConfig failure
+    fs.writeFileSync(
+      path.join(TEST_DIR, "skittles.config.json"),
+      "invalid json"
+    );
+
+    await cleanCommand(TEST_DIR);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #250

## Problem

### clean.ts
`cleanCommand()` in `src/commands/clean.ts` (16 lines) has no try/catch. If `loadConfig()` fails or `removeDirectory()` throws (e.g. permission errors), the process crashes with an unhandled exception and no user-friendly message.

### index.ts
`src/index.ts` reads `package.json` synchronously at startup (line 14–16). If the file is missing or contains invalid JSON, the CLI crashes without a helpful error message.

## Suggested Fix

Wrap both in try/catch blocks with clear error messages using the existing `logError()` helper.