### PR TITLE
Cleanup: Replace magic numbers and strings in compiler with named constants [S]

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -18,6 +18,15 @@ import {
   type SolidityConfig,
 } from "../types/index.ts";
 import { DEFAULT_CONFIG } from "../config/defaults.ts";
+import {
+  CHAR_A,
+  CHAR_Z,
+  CHAR_a,
+  CHAR_z,
+  CHAR_SPACE,
+  CHAR_0,
+  ERR_START_OUT_OF_BOUNDS,
+} from "./constants.ts";
 
 // ============================================================
 // Helper function tracking
@@ -1011,8 +1020,8 @@ function generateContractBody(
       "        bytes memory result = new bytes(strBytes.length);",
       "        for (uint256 i = 0; i < strBytes.length; i++) {",
       "            uint8 c = uint8(strBytes[i]);",
-      "            if (c >= 65 && c <= 90) {",
-      "                result[i] = bytes1(c + 32);",
+      `            if (c >= ${CHAR_A} && c <= ${CHAR_Z}) {`,
+      `                result[i] = bytes1(c + ${CHAR_SPACE});`,
       "            } else {",
       "                result[i] = strBytes[i];",
       "            }",
@@ -1029,8 +1038,8 @@ function generateContractBody(
       "        bytes memory result = new bytes(strBytes.length);",
       "        for (uint256 i = 0; i < strBytes.length; i++) {",
       "            uint8 c = uint8(strBytes[i]);",
-      "            if (c >= 97 && c <= 122) {",
-      "                result[i] = bytes1(c - 32);",
+      `            if (c >= ${CHAR_a} && c <= ${CHAR_z}) {`,
+      `                result[i] = bytes1(c - ${CHAR_SPACE});`,
       "            } else {",
       "                result[i] = strBytes[i];",
       "            }",
@@ -1075,8 +1084,8 @@ function generateContractBody(
       "        bytes memory strBytes = bytes(str);",
       "        uint256 start = 0;",
       "        uint256 end = strBytes.length;",
-      "        while (start < end && uint8(strBytes[start]) == 32) { start++; }",
-      "        while (end > start && uint8(strBytes[end - 1]) == 32) { end--; }",
+      `        while (start < end && uint8(strBytes[start]) == ${CHAR_SPACE}) { start++; }`,
+      `        while (end > start && uint8(strBytes[end - 1]) == ${CHAR_SPACE}) { end--; }`,
       "        bytes memory result = new bytes(end - start);",
       "        for (uint256 i = start; i < end; i++) {",
       "            result[i - start] = strBytes[i];",
@@ -1134,7 +1143,7 @@ function generateContractBody(
       "        bytes memory buffer = new bytes(digits);",
       "        while (value != 0) {",
       "            digits--;",
-      "            buffer[digits] = bytes1(uint8(48 + (value % 10)));",
+      `            buffer[digits] = bytes1(uint8(${CHAR_0} + (value % 10)));`,
       "            value /= 10;",
       "        }",
       "        return string(buffer);",
@@ -1289,7 +1298,7 @@ function generateContractBody(
     if (method === "splice" && needsHelper(`_arrSplice_${suffix}`, true)) {
       emitHelper(`_arrSplice_${suffix}`, [
         `    function _arrSplice_${suffix}(${solType}[] storage arr, uint256 start, uint256 deleteCount) internal {`,
-        `        require(start < arr.length, "start out of bounds");`,
+        `        require(start < arr.length, "${ERR_START_OUT_OF_BOUNDS}");`,
         `        uint256 end = start + deleteCount;`,
         `        if (end > arr.length) end = arr.length;`,
         `        uint256 removed = end - start;`,

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -29,6 +29,7 @@ import {
   buildSourceMap,
 } from "./codegen.ts";
 import { analyzeFunction } from "./analysis.ts";
+import { MUTABILITY_RANK } from "./mutability.ts";
 import {
   getStdlibClassNames,
   resolveStdlibFiles,
@@ -46,7 +47,7 @@ export interface CompilationResult {
 // Incremental compilation cache
 // ============================================================
 
-const CACHE_VERSION = "5";
+import { CACHE_VERSION } from "./constants.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_VERSION: string = JSON.parse(
@@ -486,12 +487,7 @@ export async function compile(
       ]);
 
       let changed = true;
-      const rank: Record<string, number> = {
-        pure: 0,
-        view: 1,
-        nonpayable: 2,
-        payable: 3,
-      };
+      const rank: Record<string, number> = MUTABILITY_RANK;
       while (changed) {
         changed = false;
         for (const fn of contract.functions) {

--- a/src/compiler/constants.ts
+++ b/src/compiler/constants.ts
@@ -1,0 +1,41 @@
+// ============================================================
+// Named constants for magic numbers and strings used across
+// the compiler.  Centralising these values makes intent clear
+// and avoids scattered magic literals.
+// ============================================================
+
+// -- ASCII character codes (used in Solidity string helpers) --
+
+/** ASCII code for uppercase 'A' (65) */
+export const CHAR_A = 65;
+/** ASCII code for uppercase 'Z' (90) */
+export const CHAR_Z = 90;
+/** ASCII code for lowercase 'a' (97) */
+export const CHAR_a = 97;
+/** ASCII code for lowercase 'z' (122) */
+export const CHAR_z = 122;
+/** ASCII code for space ' ' (32) */
+export const CHAR_SPACE = 32;
+/** ASCII code for digit '0' (48) */
+export const CHAR_0 = 48;
+
+// -- Error messages --
+
+/** Error string emitted by the array splice helper when the start index
+ *  exceeds the array length. */
+export const ERR_START_OUT_OF_BOUNDS = "start out of bounds";
+
+// -- Solc integration --
+
+/** Virtual filename used when compiling multiple contracts in a single
+ *  solc invocation (batch compilation). */
+export const BATCH_SOURCE_FILENAME = "Contracts.sol";
+
+// -- Incremental compilation cache --
+
+/**
+ * Bump this version whenever the on-disk cache format changes so that
+ * stale caches are automatically invalidated.  History:
+ *   "5" – current format.
+ */
+export const CACHE_VERSION = "5";

--- a/src/compiler/mutability.ts
+++ b/src/compiler/mutability.ts
@@ -21,12 +21,7 @@ import { inferType } from "./type-parser.ts";
  */
 export function propagateStateMutability(functions: SkittlesFunction[]): void {
   type Mut = "pure" | "view" | "nonpayable" | "payable";
-  const rank: Record<Mut, number> = {
-    pure: 0,
-    view: 1,
-    nonpayable: 2,
-    payable: 3,
-  };
+  const rank: Record<Mut, number> = MUTABILITY_RANK;
 
   const mutMap = new Map<string, Mut>();
   for (const f of functions) {

--- a/src/compiler/solc.ts
+++ b/src/compiler/solc.ts
@@ -1,5 +1,6 @@
 import solc from "solc";
 import type { SkittlesConfig, AbiItem } from "../types/index.ts";
+import { BATCH_SOURCE_FILENAME } from "./constants.ts";
 
 export interface SolcResult {
   abi: AbiItem[];
@@ -105,7 +106,7 @@ export function compileSolidityBatch(
   contractNames: string[],
   config: Required<SkittlesConfig>
 ): SolcBatchResult {
-  const sourceFileName = "Contracts.sol";
+  const sourceFileName = BATCH_SOURCE_FILENAME;
 
   const input = {
     language: "Solidity",


### PR DESCRIPTION
Closes #245

## Problem

Several magic values are scattered across the compiler:

### codegen.ts
- ASCII codes `65`, `90`, `97`, `122`, `32` used in string helper functions (e.g. `__sk_toUpperCase`, `__sk_toLowerCase`) — should be `CHAR_A`, `CHAR_Z`, `CHAR_a`, `CHAR_z`, `CHAR_SPACE`
- `48` for `'0'` in `__sk_toString`
- `"start out of bounds"` error string (line 817)

### compiler.ts
- `CACHE_VERSION = "5"` (line 28) — fine as a constant but not documented why it's "5"
- Mutability rank map `{ pure: 0, view: 1, nonpayable: 2, payable: 3 }` is inline (line 388)

### solc.ts
- `"Contracts.sol"` magic filename (line 103)

### parser.ts
- Various `"uint256" as SkittlesTypeKind` style casts could use shared constants

## Suggested Fix

Create a `constants.ts` file in the compiler directory (or in `types/`) to centralize these values. Use descriptive names that communicate intent.