### PR TITLE
Cleanup: Add explicit error handling for unknown expression/statement kinds in codegen [S]

### DIFF
--- a/src/compiler/analysis.ts
+++ b/src/compiler/analysis.ts
@@ -225,6 +225,10 @@ function walkAllStatements(
  */
 function collectUsedIdentifiers(expr: Expression, used: Set<string>): void {
   switch (expr.kind) {
+    case "number-literal":
+    case "string-literal":
+    case "boolean-literal":
+      break;
     case "identifier":
       used.add(expr.name);
       break;
@@ -272,5 +276,9 @@ function collectUsedIdentifiers(expr: Expression, used: Set<string>): void {
         collectUsedIdentifiers(elem, used);
       }
       break;
+    default: {
+      const _exhaustive: never = expr;
+      throw new Error(`Unhandled expression kind: ${(_exhaustive as Expression).kind}`);
+    }
   }
 }

--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -1871,8 +1871,10 @@ export function generateType(type: SkittlesType): string {
       return `(${(type.tupleTypes ?? []).map(generateType).join(", ")})`;
     case SkittlesTypeKind.Void:
       return "";
-    default:
-      return "uint256";
+    default: {
+      const _exhaustive: never = type.kind;
+      throw new Error(`Unhandled type kind: ${_exhaustive}`);
+    }
   }
 }
 
@@ -1988,8 +1990,10 @@ export function generateExpression(expr: Expression): string {
     }
     case "tuple-literal":
       return `(${expr.elements.map(generateExpression).join(", ")})`;
-    default:
-      return "/* unsupported */";
+    default: {
+      const _exhaustive: never = expr;
+      throw new Error(`Unhandled expression kind: ${(_exhaustive as Expression).kind}`);
+    }
   }
 }
 
@@ -2213,8 +2217,10 @@ export function generateStatement(stmt: Statement, indent: string): string {
     case "console-log":
       return `${indent}console.log(${stmt.args.map(generateExpression).join(", ")});`;
 
-    default:
-      return `${indent}// unsupported statement`;
+    default: {
+      const _exhaustive: never = stmt;
+      throw new Error(`Unhandled statement kind: ${(_exhaustive as Statement).kind}`);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #247

## Problem

In `src/compiler/codegen.ts`:

- `generateType()` (line 1188) returns `"uint256"` as a silent default for unknown type kinds instead of throwing or logging a warning
- `generateExpression()` (line 1252) returns `"/* unsupported */"` for unknown expression kinds

In `src/compiler/analysis.ts`:

- `collectUsedIdentifiers()` (lines 218–269) has no `default` case, so new expression kinds will be silently ignored

## Why This Matters

Silent defaults hide bugs. When a new expression or statement kind is added to the IR, these functions will silently produce incorrect output instead of failing fast and alerting the developer.

## Suggested Fix

Replace silent defaults with explicit `exhaustive check` patterns:

```typescript
default:
  const _exhaustive: never = kind;
  throw new Error(`Unhandled expression kind: ${kind}`);
```

Or at minimum, emit a compile-time warning that can be surfaced to the user.