### PR TITLE
Refactor: Extract shared AST walking utilities from parser, analysis, and compiler [M]

### DIFF
--- a/src/compiler/analysis.ts
+++ b/src/compiler/analysis.ts
@@ -4,6 +4,7 @@ import type {
   SkittlesFunction,
   SkittlesConstructor,
 } from "../types/index.ts";
+import { walkStatements } from "./walker.ts";
 
 /**
  * Analyze a function body for unreachable code and unused local variables.
@@ -135,150 +136,29 @@ function checkUnusedVariables(
 
 /**
  * Walk all statements recursively, collecting declared variable names
- * and used identifier names.
+ * and used identifier names via the shared AST walker.
  */
 function walkAllStatements(
   stmts: Statement[],
   declared: Set<string>,
   used: Set<string>
 ): void {
-  for (const stmt of stmts) {
-    switch (stmt.kind) {
-      case "variable-declaration":
+  walkStatements(stmts, {
+    visitStatement(stmt) {
+      if (stmt.kind === "variable-declaration") {
         declared.add(stmt.name);
-        if (stmt.initializer) collectUsedIdentifiers(stmt.initializer, used);
-        break;
-      case "tuple-destructuring":
+      }
+      if (stmt.kind === "tuple-destructuring") {
         for (const n of stmt.names) if (n !== null) declared.add(n);
-        collectUsedIdentifiers(stmt.initializer, used);
-        break;
-      case "return":
-        if (stmt.value) collectUsedIdentifiers(stmt.value, used);
-        break;
-      case "expression":
-        collectUsedIdentifiers(stmt.expression, used);
-        break;
-      case "if":
-        collectUsedIdentifiers(stmt.condition, used);
-        walkAllStatements(stmt.thenBody, declared, used);
-        if (stmt.elseBody) walkAllStatements(stmt.elseBody, declared, used);
-        break;
-      case "for":
-        if (stmt.initializer) {
-          if (stmt.initializer.kind === "variable-declaration") {
-            declared.add(stmt.initializer.name);
-            if (stmt.initializer.initializer)
-              collectUsedIdentifiers(stmt.initializer.initializer, used);
-          } else {
-            collectUsedIdentifiers(stmt.initializer.expression, used);
-          }
-        }
-        if (stmt.condition) collectUsedIdentifiers(stmt.condition, used);
-        if (stmt.incrementor) collectUsedIdentifiers(stmt.incrementor, used);
-        walkAllStatements(stmt.body, declared, used);
-        break;
-      case "while":
-      case "do-while":
-        collectUsedIdentifiers(stmt.condition, used);
-        walkAllStatements(stmt.body, declared, used);
-        break;
-      case "revert":
-        if (stmt.message) collectUsedIdentifiers(stmt.message, used);
-        if (stmt.customErrorArgs) {
-          for (const arg of stmt.customErrorArgs) {
-            collectUsedIdentifiers(arg, used);
-          }
-        }
-        break;
-      case "emit":
-        for (const arg of stmt.args) {
-          collectUsedIdentifiers(arg, used);
-        }
-        break;
-      case "switch":
-        collectUsedIdentifiers(stmt.discriminant, used);
-        for (const c of stmt.cases) {
-          if (c.value) collectUsedIdentifiers(c.value, used);
-          walkAllStatements(c.body, declared, used);
-        }
-        break;
-      case "delete":
-        collectUsedIdentifiers(stmt.target, used);
-        break;
-      case "try-catch":
-        collectUsedIdentifiers(stmt.call, used);
-        if (stmt.returnVarName) declared.add(stmt.returnVarName);
-        walkAllStatements(stmt.successBody, declared, used);
-        walkAllStatements(stmt.catchBody, declared, used);
-        break;
-      case "console-log":
-        for (const arg of stmt.args) {
-          collectUsedIdentifiers(arg, used);
-        }
-        break;
-    }
-  }
-}
-
-/**
- * Collect all identifier names used in an expression.
- */
-function collectUsedIdentifiers(expr: Expression, used: Set<string>): void {
-  switch (expr.kind) {
-    case "number-literal":
-    case "string-literal":
-    case "boolean-literal":
-      break;
-    case "identifier":
-      used.add(expr.name);
-      break;
-    case "binary":
-      collectUsedIdentifiers(expr.left, used);
-      collectUsedIdentifiers(expr.right, used);
-      break;
-    case "unary":
-      collectUsedIdentifiers(expr.operand, used);
-      break;
-    case "assignment":
-      collectUsedIdentifiers(expr.target, used);
-      collectUsedIdentifiers(expr.value, used);
-      break;
-    case "call":
-      collectUsedIdentifiers(expr.callee, used);
-      for (const arg of expr.args) {
-        collectUsedIdentifiers(arg, used);
       }
-      break;
-    case "property-access":
-      collectUsedIdentifiers(expr.object, used);
-      break;
-    case "element-access":
-      collectUsedIdentifiers(expr.object, used);
-      collectUsedIdentifiers(expr.index, used);
-      break;
-    case "conditional":
-      collectUsedIdentifiers(expr.condition, used);
-      collectUsedIdentifiers(expr.whenTrue, used);
-      collectUsedIdentifiers(expr.whenFalse, used);
-      break;
-    case "new":
-      for (const arg of expr.args) {
-        collectUsedIdentifiers(arg, used);
+      if (stmt.kind === "try-catch" && stmt.returnVarName) {
+        declared.add(stmt.returnVarName);
       }
-      break;
-    case "object-literal":
-      for (const prop of expr.properties) {
-        collectUsedIdentifiers(prop.value, used);
+    },
+    visitExpression(expr) {
+      if (expr.kind === "identifier") {
+        used.add(expr.name);
       }
-      break;
-    case "tuple-literal":
-      for (const elem of expr.elements) {
-        collectUsedIdentifiers(elem, used);
-      }
-      break;
-    default: {
-      const _exhaustive: never = expr;
-      throw new Error(`Unhandled expression kind: ${(_exhaustive as Expression).kind}`);
-    }
-  }
+    },
+  });
 }

--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -378,14 +378,16 @@ export function parseClass(
   const fileFnNames = new Set(fileFunctions.map((f) => f.name));
   const usedFileFnNames = new Set<string>();
   const collectFnCalls = (stmts: Statement[]) => {
-    walkStatements(stmts, (expr) => {
-      if (
-        expr.kind === "call" &&
-        expr.callee.kind === "identifier" &&
-        fileFnNames.has(expr.callee.name)
-      ) {
-        usedFileFnNames.add(expr.callee.name);
-      }
+    walkStatements(stmts, {
+      visitExpression(expr) {
+        if (
+          expr.kind === "call" &&
+          expr.callee.kind === "identifier" &&
+          fileFnNames.has(expr.callee.name)
+        ) {
+          usedFileFnNames.add(expr.callee.name);
+        }
+      },
     });
   };
   for (const f of functions) collectFnCalls(f.body);
@@ -394,14 +396,16 @@ export function parseClass(
     if (v.initialValue) {
       walkStatements(
         [{ kind: "expression", expression: v.initialValue }],
-        (expr) => {
-          if (
-            expr.kind === "call" &&
-            expr.callee.kind === "identifier" &&
-            fileFnNames.has(expr.callee.name)
-          ) {
-            usedFileFnNames.add(expr.callee.name);
-          }
+        {
+          visitExpression(expr) {
+            if (
+              expr.kind === "call" &&
+              expr.callee.kind === "identifier" &&
+              fileFnNames.has(expr.callee.name)
+            ) {
+              usedFileFnNames.add(expr.callee.name);
+            }
+          },
         }
       );
     }
@@ -412,16 +416,18 @@ export function parseClass(
     fnChanged = false;
     for (const fn of fileFunctions) {
       if (!usedFileFnNames.has(fn.name)) continue;
-      walkStatements(fn.body, (expr) => {
-        if (
-          expr.kind === "call" &&
-          expr.callee.kind === "identifier" &&
-          fileFnNames.has(expr.callee.name) &&
-          !usedFileFnNames.has(expr.callee.name)
-        ) {
-          usedFileFnNames.add(expr.callee.name);
-          fnChanged = true;
-        }
+      walkStatements(fn.body, {
+        visitExpression(expr) {
+          if (
+            expr.kind === "call" &&
+            expr.callee.kind === "identifier" &&
+            fileFnNames.has(expr.callee.name) &&
+            !usedFileFnNames.has(expr.callee.name)
+          ) {
+            usedFileFnNames.add(expr.callee.name);
+            fnChanged = true;
+          }
+        },
       });
     }
   }
@@ -470,9 +476,8 @@ export function parseClass(
       for (const f of type.structFields) collectTypeRef(f.type);
   };
   const collectBodyTypeRefs = (stmts: Statement[]) => {
-    walkStatements(
-      stmts,
-      (expr) => {
+    walkStatements(stmts, {
+      visitExpression(expr) {
         // Enum member access: Color.Red
         if (
           expr.kind === "property-access" &&
@@ -486,13 +491,13 @@ export function parseClass(
           for (const t of expr.typeArgs) collectTypeRef(t);
         }
       },
-      (stmt) => {
+      visitStatement(stmt) {
         if (stmt.kind === "variable-declaration" && stmt.type)
           collectTypeRef(stmt.type);
         if (stmt.kind === "try-catch" && stmt.returnType)
           collectTypeRef(stmt.returnType);
-      }
-    );
+      },
+    });
   };
   for (const v of variables) {
     collectTypeRef(v.type);

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -30,6 +30,7 @@ import {
 } from "./codegen.ts";
 import { analyzeFunction } from "./analysis.ts";
 import { MUTABILITY_RANK } from "./mutability.ts";
+import { walkStatements } from "./walker.ts";
 import {
   getStdlibClassNames,
   resolveStdlibFiles,
@@ -943,119 +944,22 @@ function collectThisCallNames(stmts: Statement[]): {
   const thisCalls: string[] = [];
   const superCalls: string[] = [];
 
-  function walkExpr(expr: Expression): void {
-    switch (expr.kind) {
-      case "call":
-        if (
-          expr.callee.kind === "property-access" &&
-          expr.callee.object.kind === "identifier"
-        ) {
-          if (expr.callee.object.name === "this") {
-            thisCalls.push(expr.callee.property);
-          } else if (expr.callee.object.name === "super") {
-            superCalls.push(expr.callee.property);
-          }
+  walkStatements(stmts, {
+    visitExpression(expr) {
+      if (
+        expr.kind === "call" &&
+        expr.callee.kind === "property-access" &&
+        expr.callee.object.kind === "identifier"
+      ) {
+        if (expr.callee.object.name === "this") {
+          thisCalls.push(expr.callee.property);
+        } else if (expr.callee.object.name === "super") {
+          superCalls.push(expr.callee.property);
         }
-        walkExpr(expr.callee);
-        expr.args.forEach(walkExpr);
-        break;
-      case "binary":
-        walkExpr(expr.left);
-        walkExpr(expr.right);
-        break;
-      case "unary":
-        walkExpr(expr.operand);
-        break;
-      case "assignment":
-        walkExpr(expr.target);
-        walkExpr(expr.value);
-        break;
-      case "property-access":
-        walkExpr(expr.object);
-        break;
-      case "element-access":
-        walkExpr(expr.object);
-        walkExpr(expr.index);
-        break;
-      case "conditional":
-        walkExpr(expr.condition);
-        walkExpr(expr.whenTrue);
-        walkExpr(expr.whenFalse);
-        break;
-      case "new":
-        expr.args.forEach(walkExpr);
-        break;
-      case "object-literal":
-        expr.properties.forEach((p) => walkExpr(p.value));
-        break;
-      case "tuple-literal":
-        expr.elements.forEach(walkExpr);
-        break;
-    }
-  }
+      }
+    },
+  });
 
-  function walkStmt(stmt: Statement): void {
-    switch (stmt.kind) {
-      case "return":
-        if (stmt.value) walkExpr(stmt.value);
-        break;
-      case "variable-declaration":
-        if (stmt.initializer) walkExpr(stmt.initializer);
-        break;
-      case "tuple-destructuring":
-        walkExpr(stmt.initializer);
-        break;
-      case "expression":
-        walkExpr(stmt.expression);
-        break;
-      case "if":
-        walkExpr(stmt.condition);
-        stmt.thenBody.forEach(walkStmt);
-        stmt.elseBody?.forEach(walkStmt);
-        break;
-      case "for":
-        if (stmt.initializer) walkStmt(stmt.initializer);
-        if (stmt.condition) walkExpr(stmt.condition);
-        if (stmt.incrementor) walkExpr(stmt.incrementor);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "while":
-        walkExpr(stmt.condition);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "revert":
-        if (stmt.message) walkExpr(stmt.message);
-        if (stmt.customErrorArgs) stmt.customErrorArgs.forEach(walkExpr);
-        break;
-      case "do-while":
-        walkExpr(stmt.condition);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "emit":
-        stmt.args.forEach(walkExpr);
-        break;
-      case "switch":
-        walkExpr(stmt.discriminant);
-        for (const c of stmt.cases) {
-          if (c.value) walkExpr(c.value);
-          c.body.forEach(walkStmt);
-        }
-        break;
-      case "delete":
-        walkExpr(stmt.target);
-        break;
-      case "try-catch":
-        walkExpr(stmt.call);
-        stmt.successBody.forEach(walkStmt);
-        stmt.catchBody.forEach(walkStmt);
-        break;
-      case "console-log":
-        stmt.args.forEach(walkExpr);
-        break;
-    }
-  }
-
-  stmts.forEach(walkStmt);
   return { thisCalls, superCalls };
 }
 

--- a/src/compiler/mutability.ts
+++ b/src/compiler/mutability.ts
@@ -12,6 +12,9 @@ import {
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import { inferType } from "./type-parser.ts";
+import { walkStatements as walkStatementsShared } from "./walker.ts";
+export { walkStatements, walkExpression } from "./walker.ts";
+export type { ASTVisitor } from "./walker.ts";
 
 /**
  * Propagate state mutability across call chains.
@@ -50,134 +53,21 @@ export function propagateStateMutability(functions: SkittlesFunction[]): void {
   }
 }
 
-/**
- * Generic AST walker. Calls onExpr for every expression and onStmt for every
- * statement in the tree. Both callbacks are optional.
- */
-export function walkStatements(
-  stmts: Statement[],
-  onExpr?: (expr: Expression) => void,
-  onStmt?: (stmt: Statement) => void
-): void {
-  function walkExpr(expr: Expression): void {
-    if (onExpr) onExpr(expr);
-    switch (expr.kind) {
-      case "binary":
-        walkExpr(expr.left);
-        walkExpr(expr.right);
-        break;
-      case "unary":
-        walkExpr(expr.operand);
-        break;
-      case "assignment":
-        walkExpr(expr.target);
-        walkExpr(expr.value);
-        break;
-      case "call":
-        walkExpr(expr.callee);
-        expr.args.forEach(walkExpr);
-        break;
-      case "property-access":
-        walkExpr(expr.object);
-        break;
-      case "element-access":
-        walkExpr(expr.object);
-        walkExpr(expr.index);
-        break;
-      case "conditional":
-        walkExpr(expr.condition);
-        walkExpr(expr.whenTrue);
-        walkExpr(expr.whenFalse);
-        break;
-      case "new":
-        expr.args.forEach(walkExpr);
-        break;
-      case "object-literal":
-        expr.properties.forEach((p) => walkExpr(p.value));
-        break;
-      case "tuple-literal":
-        expr.elements.forEach(walkExpr);
-        break;
-    }
-  }
-
-  function walkStmt(stmt: Statement): void {
-    if (onStmt) onStmt(stmt);
-    switch (stmt.kind) {
-      case "return":
-        if (stmt.value) walkExpr(stmt.value);
-        break;
-      case "variable-declaration":
-        if (stmt.initializer) walkExpr(stmt.initializer);
-        break;
-      case "tuple-destructuring":
-        walkExpr(stmt.initializer);
-        break;
-      case "expression":
-        walkExpr(stmt.expression);
-        break;
-      case "if":
-        walkExpr(stmt.condition);
-        stmt.thenBody.forEach(walkStmt);
-        stmt.elseBody?.forEach(walkStmt);
-        break;
-      case "for":
-        if (stmt.initializer) walkStmt(stmt.initializer);
-        if (stmt.condition) walkExpr(stmt.condition);
-        if (stmt.incrementor) walkExpr(stmt.incrementor);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "while":
-        walkExpr(stmt.condition);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "revert":
-        if (stmt.message) walkExpr(stmt.message);
-        if (stmt.customErrorArgs) stmt.customErrorArgs.forEach(walkExpr);
-        break;
-      case "do-while":
-        walkExpr(stmt.condition);
-        stmt.body.forEach(walkStmt);
-        break;
-      case "emit":
-        stmt.args.forEach(walkExpr);
-        break;
-      case "switch":
-        walkExpr(stmt.discriminant);
-        for (const c of stmt.cases) {
-          if (c.value) walkExpr(c.value);
-          c.body.forEach(walkStmt);
-        }
-        break;
-      case "delete":
-        walkExpr(stmt.target);
-        break;
-      case "try-catch":
-        walkExpr(stmt.call);
-        stmt.successBody.forEach(walkStmt);
-        stmt.catchBody.forEach(walkStmt);
-        break;
-      case "console-log":
-        stmt.args.forEach(walkExpr);
-        break;
-    }
-  }
-
-  stmts.forEach(walkStmt);
-}
 
 export function collectThisCalls(stmts: Statement[]): string[] {
   const names: string[] = [];
-  walkStatements(stmts, (expr) => {
-    if (
-      expr.kind === "call" &&
-      expr.callee.kind === "property-access" &&
-      expr.callee.object.kind === "identifier" &&
-      (expr.callee.object.name === "this" ||
-        expr.callee.object.name === "super")
-    ) {
-      names.push(expr.callee.property);
-    }
+  walkStatementsShared(stmts, {
+    visitExpression(expr) {
+      if (
+        expr.kind === "call" &&
+        expr.callee.kind === "property-access" &&
+        expr.callee.object.kind === "identifier" &&
+        (expr.callee.object.name === "this" ||
+          expr.callee.object.name === "super")
+      ) {
+        names.push(expr.callee.property);
+      }
+    },
   });
   return names;
 }
@@ -194,9 +84,8 @@ export function collectExternalInterfaceCalls(
   const calls: { ifaceName: string; methodName: string }[] = [];
   // Track local variable types for detecting external contract calls on locals
   const localVarTypes = new Map<string, SkittlesType>(allVarTypes);
-  walkStatements(
-    stmts,
-    (expr) => {
+  walkStatementsShared(stmts, {
+    visitExpression(expr) {
       if (expr.kind !== "call" || expr.callee.kind !== "property-access")
         return;
       const methodName = expr.callee.property;
@@ -230,7 +119,7 @@ export function collectExternalInterfaceCalls(
         }
       }
     },
-    (stmt) => {
+    visitStatement(stmt) {
       // Track local variable declarations of contract-interface types
       if (
         stmt.kind === "variable-declaration" &&
@@ -240,8 +129,8 @@ export function collectExternalInterfaceCalls(
       ) {
         localVarTypes.set(stmt.name, stmt.type);
       }
-    }
-  );
+    },
+  });
   return calls;
 }
 
@@ -517,9 +406,8 @@ export function inferStateMutability(
     combinedVarTypes.set(key, value);
   });
 
-  walkStatements(
-    body,
-    (expr) => {
+  walkStatementsShared(body, {
+    visitExpression(expr) {
       if (
         expr.kind === "call" &&
         expr.callee.kind === "property-access" &&
@@ -657,7 +545,7 @@ export function inferStateMutability(
         }
       }
     },
-    (stmt) => {
+    visitStatement(stmt) {
       if (stmt.kind === "emit") {
         writesState = true;
       }
@@ -685,8 +573,8 @@ export function inferStateMutability(
           combinedVarTypes.set(stmt.name, stmt.type);
         }
       }
-    }
-  );
+    },
+  });
 
   if (usesMsgValue) return "payable";
   if (writesState) return "nonpayable";

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -17,7 +17,6 @@ import {
   inferStateMutability,
   MUTABILITY_RANK,
   propagateMutability,
-  walkStatements,
 } from "./mutability.ts";
 import {
   parseStandaloneFunction,

--- a/src/compiler/walker.ts
+++ b/src/compiler/walker.ts
@@ -1,0 +1,130 @@
+import type { Statement, Expression } from "../types/index.ts";
+
+/**
+ * Visitor interface for walking AST nodes. Both callbacks are optional;
+ * only the ones you provide will be invoked.
+ */
+export interface ASTVisitor {
+  visitExpression?(expr: Expression): void;
+  visitStatement?(stmt: Statement): void;
+}
+
+/**
+ * Walk an expression tree, invoking the visitor's `visitExpression` callback
+ * (if provided) on every expression node in pre-order.
+ */
+export function walkExpression(expr: Expression, visitor: ASTVisitor): void {
+  if (visitor.visitExpression) visitor.visitExpression(expr);
+  switch (expr.kind) {
+    case "binary":
+      walkExpression(expr.left, visitor);
+      walkExpression(expr.right, visitor);
+      break;
+    case "unary":
+      walkExpression(expr.operand, visitor);
+      break;
+    case "assignment":
+      walkExpression(expr.target, visitor);
+      walkExpression(expr.value, visitor);
+      break;
+    case "call":
+      walkExpression(expr.callee, visitor);
+      expr.args.forEach((a) => walkExpression(a, visitor));
+      break;
+    case "property-access":
+      walkExpression(expr.object, visitor);
+      break;
+    case "element-access":
+      walkExpression(expr.object, visitor);
+      walkExpression(expr.index, visitor);
+      break;
+    case "conditional":
+      walkExpression(expr.condition, visitor);
+      walkExpression(expr.whenTrue, visitor);
+      walkExpression(expr.whenFalse, visitor);
+      break;
+    case "new":
+      expr.args.forEach((a) => walkExpression(a, visitor));
+      break;
+    case "object-literal":
+      expr.properties.forEach((p) => walkExpression(p.value, visitor));
+      break;
+    case "tuple-literal":
+      expr.elements.forEach((e) => walkExpression(e, visitor));
+      break;
+  }
+}
+
+/**
+ * Walk a list of statements, invoking the visitor's `visitStatement` and
+ * `visitExpression` callbacks on every node in pre-order.
+ */
+export function walkStatements(
+  stmts: Statement[],
+  visitor: ASTVisitor
+): void {
+  function walkStmt(stmt: Statement): void {
+    if (visitor.visitStatement) visitor.visitStatement(stmt);
+    switch (stmt.kind) {
+      case "return":
+        if (stmt.value) walkExpression(stmt.value, visitor);
+        break;
+      case "variable-declaration":
+        if (stmt.initializer) walkExpression(stmt.initializer, visitor);
+        break;
+      case "tuple-destructuring":
+        walkExpression(stmt.initializer, visitor);
+        break;
+      case "expression":
+        walkExpression(stmt.expression, visitor);
+        break;
+      case "if":
+        walkExpression(stmt.condition, visitor);
+        stmt.thenBody.forEach(walkStmt);
+        stmt.elseBody?.forEach(walkStmt);
+        break;
+      case "for":
+        if (stmt.initializer) walkStmt(stmt.initializer);
+        if (stmt.condition) walkExpression(stmt.condition, visitor);
+        if (stmt.incrementor) walkExpression(stmt.incrementor, visitor);
+        stmt.body.forEach(walkStmt);
+        break;
+      case "while":
+        walkExpression(stmt.condition, visitor);
+        stmt.body.forEach(walkStmt);
+        break;
+      case "revert":
+        if (stmt.message) walkExpression(stmt.message, visitor);
+        if (stmt.customErrorArgs)
+          stmt.customErrorArgs.forEach((a) => walkExpression(a, visitor));
+        break;
+      case "do-while":
+        walkExpression(stmt.condition, visitor);
+        stmt.body.forEach(walkStmt);
+        break;
+      case "emit":
+        stmt.args.forEach((a) => walkExpression(a, visitor));
+        break;
+      case "switch":
+        walkExpression(stmt.discriminant, visitor);
+        for (const c of stmt.cases) {
+          if (c.value) walkExpression(c.value, visitor);
+          c.body.forEach(walkStmt);
+        }
+        break;
+      case "delete":
+        walkExpression(stmt.target, visitor);
+        break;
+      case "try-catch":
+        walkExpression(stmt.call, visitor);
+        stmt.successBody.forEach(walkStmt);
+        stmt.catchBody.forEach(walkStmt);
+        break;
+      case "console-log":
+        stmt.args.forEach((a) => walkExpression(a, visitor));
+        break;
+    }
+  }
+
+  stmts.forEach(walkStmt);
+}

--- a/test/compiler/walker.test.ts
+++ b/test/compiler/walker.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect } from "vitest";
+import { walkStatements, walkExpression } from "../../src/compiler/walker";
+import type { ASTVisitor } from "../../src/compiler/walker";
+import type { Statement, Expression } from "../../src/types/index";
+
+// ============================================================
+// walkExpression
+// ============================================================
+
+describe("walkExpression", () => {
+  it("should visit a simple identifier", () => {
+    const visited: string[] = [];
+    const expr: Expression = { kind: "identifier", name: "x" };
+    walkExpression(expr, {
+      visitExpression(e) {
+        visited.push(e.kind);
+      },
+    });
+    expect(visited).toEqual(["identifier"]);
+  });
+
+  it("should visit all nodes in a binary expression", () => {
+    const visited: string[] = [];
+    const expr: Expression = {
+      kind: "binary",
+      operator: "+",
+      left: { kind: "identifier", name: "a" },
+      right: { kind: "number-literal", value: "1" },
+    };
+    walkExpression(expr, {
+      visitExpression(e) {
+        visited.push(e.kind);
+      },
+    });
+    expect(visited).toEqual(["binary", "identifier", "number-literal"]);
+  });
+
+  it("should visit callee and args in a call expression", () => {
+    const visited: string[] = [];
+    const expr: Expression = {
+      kind: "call",
+      callee: { kind: "identifier", name: "foo" },
+      args: [
+        { kind: "number-literal", value: "1" },
+        { kind: "identifier", name: "x" },
+      ],
+    };
+    walkExpression(expr, {
+      visitExpression(e) {
+        visited.push(e.kind);
+      },
+    });
+    expect(visited).toEqual(["call", "identifier", "number-literal", "identifier"]);
+  });
+
+  it("should visit nested property-access expressions", () => {
+    const names: string[] = [];
+    const expr: Expression = {
+      kind: "property-access",
+      object: { kind: "identifier", name: "this" },
+      property: "balance",
+    };
+    walkExpression(expr, {
+      visitExpression(e) {
+        if (e.kind === "identifier") names.push(e.name);
+      },
+    });
+    expect(names).toEqual(["this"]);
+  });
+
+  it("should visit conditional branches", () => {
+    const visited: string[] = [];
+    const expr: Expression = {
+      kind: "conditional",
+      condition: { kind: "boolean-literal", value: true },
+      whenTrue: { kind: "number-literal", value: "1" },
+      whenFalse: { kind: "number-literal", value: "2" },
+    };
+    walkExpression(expr, {
+      visitExpression(e) {
+        visited.push(e.kind);
+      },
+    });
+    expect(visited).toEqual([
+      "conditional",
+      "boolean-literal",
+      "number-literal",
+      "number-literal",
+    ]);
+  });
+
+  it("should not crash when no visitor callbacks are provided", () => {
+    const expr: Expression = { kind: "identifier", name: "x" };
+    expect(() => walkExpression(expr, {})).not.toThrow();
+  });
+});
+
+// ============================================================
+// walkStatements
+// ============================================================
+
+describe("walkStatements", () => {
+  it("should visit statements and expressions", () => {
+    const stmtKinds: string[] = [];
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "variable-declaration",
+        name: "x",
+        type: null,
+        initializer: { kind: "number-literal", value: "42" },
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["variable-declaration"]);
+    expect(exprKinds).toEqual(["number-literal"]);
+  });
+
+  it("should recurse into if-else bodies", () => {
+    const stmtKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "if",
+        condition: { kind: "boolean-literal", value: true },
+        thenBody: [{ kind: "break" }],
+        elseBody: [{ kind: "continue" }],
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["if", "break", "continue"]);
+  });
+
+  it("should recurse into for loop body and initializer", () => {
+    const stmtKinds: string[] = [];
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "for",
+        initializer: {
+          kind: "variable-declaration",
+          name: "i",
+          type: null,
+          initializer: { kind: "number-literal", value: "0" },
+        },
+        condition: {
+          kind: "binary",
+          operator: "<",
+          left: { kind: "identifier", name: "i" },
+          right: { kind: "number-literal", value: "10" },
+        },
+        incrementor: {
+          kind: "unary",
+          operator: "++",
+          prefix: false,
+          operand: { kind: "identifier", name: "i" },
+        },
+        body: [{ kind: "break" }],
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["for", "variable-declaration", "break"]);
+    expect(exprKinds).toContain("number-literal");
+    expect(exprKinds).toContain("binary");
+    expect(exprKinds).toContain("unary");
+  });
+
+  it("should recurse into while and do-while bodies", () => {
+    const stmtKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "while",
+        condition: { kind: "boolean-literal", value: true },
+        body: [{ kind: "break" }],
+      },
+      {
+        kind: "do-while",
+        condition: { kind: "boolean-literal", value: false },
+        body: [{ kind: "continue" }],
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["while", "break", "do-while", "continue"]);
+  });
+
+  it("should recurse into switch cases", () => {
+    const stmtKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "switch",
+        discriminant: { kind: "identifier", name: "x" },
+        cases: [
+          {
+            value: { kind: "number-literal", value: "1" },
+            body: [{ kind: "break" }],
+          },
+          {
+            value: undefined,
+            body: [{ kind: "continue" }],
+          },
+        ],
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["switch", "break", "continue"]);
+  });
+
+  it("should recurse into try-catch bodies", () => {
+    const stmtKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "try-catch",
+        call: { kind: "call", callee: { kind: "identifier", name: "foo" }, args: [] },
+        successBody: [{ kind: "break" }],
+        catchBody: [{ kind: "continue" }],
+        catchParamName: "e",
+      },
+    ];
+    walkStatements(stmts, {
+      visitStatement(s) {
+        stmtKinds.push(s.kind);
+      },
+    });
+    expect(stmtKinds).toEqual(["try-catch", "break", "continue"]);
+  });
+
+  it("should visit return value expression", () => {
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "return",
+        value: { kind: "identifier", name: "result" },
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(exprKinds).toEqual(["identifier"]);
+  });
+
+  it("should visit emit args", () => {
+    const names: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "emit",
+        eventName: "Transfer",
+        args: [
+          { kind: "identifier", name: "from" },
+          { kind: "identifier", name: "to" },
+        ],
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        if (e.kind === "identifier") names.push(e.name);
+      },
+    });
+    expect(names).toEqual(["from", "to"]);
+  });
+
+  it("should visit delete target", () => {
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "delete",
+        target: { kind: "identifier", name: "x" },
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(exprKinds).toEqual(["identifier"]);
+  });
+
+  it("should visit revert message and custom error args", () => {
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "revert",
+        message: { kind: "string-literal", value: "error" },
+        customErrorArgs: [{ kind: "number-literal", value: "1" }],
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(exprKinds).toEqual(["string-literal", "number-literal"]);
+  });
+
+  it("should visit console-log args", () => {
+    const exprKinds: string[] = [];
+    const stmts: Statement[] = [
+      {
+        kind: "console-log",
+        args: [
+          { kind: "string-literal", value: "hello" },
+          { kind: "identifier", name: "x" },
+        ],
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        exprKinds.push(e.kind);
+      },
+    });
+    expect(exprKinds).toEqual(["string-literal", "identifier"]);
+  });
+
+  it("should not crash with empty visitor", () => {
+    const stmts: Statement[] = [
+      { kind: "break" },
+      { kind: "continue" },
+    ];
+    expect(() => walkStatements(stmts, {})).not.toThrow();
+  });
+
+  it("should collect all identifiers in a complex statement tree", () => {
+    const identifiers = new Set<string>();
+    const stmts: Statement[] = [
+      {
+        kind: "variable-declaration",
+        name: "x",
+        type: null,
+        initializer: {
+          kind: "binary",
+          operator: "+",
+          left: { kind: "identifier", name: "a" },
+          right: { kind: "identifier", name: "b" },
+        },
+      },
+      {
+        kind: "if",
+        condition: { kind: "identifier", name: "flag" },
+        thenBody: [
+          {
+            kind: "return",
+            value: { kind: "identifier", name: "x" },
+          },
+        ],
+      },
+    ];
+    walkStatements(stmts, {
+      visitExpression(e) {
+        if (e.kind === "identifier") identifiers.add(e.name);
+      },
+    });
+    expect(identifiers).toEqual(new Set(["a", "b", "flag", "x"]));
+  });
+});


### PR DESCRIPTION
Closes #243

## Problem

Statement and expression traversal logic is duplicated across three files:

- `src/compiler/analysis.ts` — walks statements/expressions for unreachable code and unused variable detection
- `src/compiler/compiler.ts` — `collectThisCallNames` walks statements/expressions to find method calls
- `src/compiler/parser.ts` — various traversals for state mutability inference and type collection

Each file implements its own recursive `walkStmt`/`walkExpr` pattern with slightly different visitors.

## Suggested Fix

Create a shared `src/compiler/walker.ts` module with a generic visitor pattern:

```typescript
interface ASTVisitor {
  visitExpression?(expr: Expression): void;
  visitStatement?(stmt: Statement): void;
}

function walkStatements(stmts: Statement[], visitor: ASTVisitor): void { ... }
function walkExpression(expr: Expression, visitor: ASTVisitor): void { ... }
```

Each consumer then only needs to define the specific visit callbacks it cares about, rather than reimplementing the full traversal.