### PR TITLE
Refactor: Consolidate compileSolidity and compileSolidityBatch in solc.ts [S]

### DIFF
--- a/src/compiler/solc.ts
+++ b/src/compiler/solc.ts
@@ -9,23 +9,36 @@ export interface SolcResult {
   warnings: string[];
 }
 
+export interface SolcBatchResult {
+  contracts: Record<string, { abi: AbiItem[]; bytecode: string }>;
+  errors: string[];
+  warnings: string[];
+}
+
+/** Raw output returned by the shared `runSolc` helper. */
+interface SolcRawOutput {
+  /** Parsed solc JSON output, or `undefined` when compilation threw. */
+  output: Record<string, unknown> | undefined;
+  errors: string[];
+  warnings: string[];
+}
+
 /**
- * Compile Solidity source code to ABI and bytecode using solc.
- *
- * This is the final compilation stage: Solidity -> EVM bytecode.
+ * Shared core that constructs solc input JSON, invokes `solc.compile()`, and
+ * classifies any diagnostics into errors / warnings.
  */
-export function compileSolidity(
-  contractName: string,
-  soliditySource: string,
+function runSolc(
+  sources: Record<string, string>,
   config: Required<SkittlesConfig>
-): SolcResult {
+): SolcRawOutput {
+  const sourcesInput: Record<string, { content: string }> = {};
+  for (const [name, content] of Object.entries(sources)) {
+    sourcesInput[name] = { content };
+  }
+
   const input = {
     language: "Solidity",
-    sources: {
-      [`${contractName}.sol`]: {
-        content: soliditySource,
-      },
-    },
+    sources: sourcesInput,
     settings: {
       optimizer: {
         enabled: config.optimizer.enabled,
@@ -45,8 +58,7 @@ export function compileSolidity(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {
-      abi: [],
-      bytecode: "",
+      output: undefined,
       errors: [`Solc compilation failed: ${msg}`],
       warnings: [],
     };
@@ -66,19 +78,38 @@ export function compileSolidity(
     }
   }
 
-  if (errors.length > 0) {
-    return { abi: [], bytecode: "", errors, warnings };
+  return { output, errors, warnings };
+}
+
+/**
+ * Compile Solidity source code to ABI and bytecode using solc.
+ *
+ * This is the final compilation stage: Solidity -> EVM bytecode.
+ */
+export function compileSolidity(
+  contractName: string,
+  soliditySource: string,
+  config: Required<SkittlesConfig>
+): SolcResult {
+  const sourceFileName = `${contractName}.sol`;
+  const raw = runSolc({ [sourceFileName]: soliditySource }, config);
+
+  if (raw.errors.length > 0) {
+    return { abi: [], bytecode: "", errors: raw.errors, warnings: raw.warnings };
   }
 
+  const output = raw.output as Record<string, unknown>;
   const contractOutput =
-    output.contracts?.[`${contractName}.sol`]?.[contractName];
+    (output.contracts as Record<string, Record<string, unknown>>)?.[sourceFileName]?.[contractName] as
+      | { abi?: AbiItem[]; evm?: { bytecode?: { object?: string } } }
+      | undefined;
 
   if (!contractOutput) {
     return {
       abi: [],
       bytecode: "",
       errors: [`No output found for contract ${contractName}`],
-      warnings,
+      warnings: raw.warnings,
     };
   }
 
@@ -86,14 +117,8 @@ export function compileSolidity(
     abi: contractOutput.abi || [],
     bytecode: contractOutput.evm?.bytecode?.object || "",
     errors: [],
-    warnings,
+    warnings: raw.warnings,
   };
-}
-
-export interface SolcBatchResult {
-  contracts: Record<string, { abi: AbiItem[]; bytecode: string }>;
-  errors: string[];
-  warnings: string[];
 }
 
 /**
@@ -107,62 +132,21 @@ export function compileSolidityBatch(
   config: Required<SkittlesConfig>
 ): SolcBatchResult {
   const sourceFileName = BATCH_SOURCE_FILENAME;
+  const raw = runSolc({ [sourceFileName]: soliditySource }, config);
 
-  const input = {
-    language: "Solidity",
-    sources: {
-      [sourceFileName]: {
-        content: soliditySource,
-      },
-    },
-    settings: {
-      optimizer: {
-        enabled: config.optimizer.enabled,
-        runs: config.optimizer.runs,
-      },
-      outputSelection: {
-        "*": {
-          "*": ["abi", "evm.bytecode.object"],
-        },
-      },
-    },
-  };
-
-  let output;
-  try {
-    output = JSON.parse(solc.compile(JSON.stringify(input)));
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return {
-      contracts: {},
-      errors: [`Solc compilation failed: ${msg}`],
-      warnings: [],
-    };
+  if (raw.errors.length > 0) {
+    return { contracts: {}, errors: raw.errors, warnings: raw.warnings };
   }
 
-  const errors: string[] = [];
-  const warnings: string[] = [];
-
-  if (output.errors) {
-    for (const error of output.errors) {
-      const message = error.formattedMessage || error.message;
-      if (error.severity === "error") {
-        errors.push(message);
-      } else if (error.severity === "warning") {
-        warnings.push(message);
-      }
-    }
-  }
-
-  if (errors.length > 0) {
-    return { contracts: {}, errors, warnings };
-  }
-
-  const fileContracts = output.contracts?.[sourceFileName] ?? {};
+  const output = raw.output as Record<string, unknown>;
+  const fileContracts =
+    (output.contracts as Record<string, Record<string, unknown>>)?.[sourceFileName] ?? {};
   const result: Record<string, { abi: AbiItem[]; bytecode: string }> = {};
 
   for (const name of contractNames) {
-    const contractOutput = fileContracts[name];
+    const contractOutput = fileContracts[name] as
+      | { abi?: AbiItem[]; evm?: { bytecode?: { object?: string } } }
+      | undefined;
     if (contractOutput) {
       result[name] = {
         abi: contractOutput.abi || [],
@@ -171,5 +155,5 @@ export function compileSolidityBatch(
     }
   }
 
-  return { contracts: result, errors: [], warnings };
+  return { contracts: result, errors: [], warnings: raw.warnings };
 }

--- a/test/compiler/solc.test.ts
+++ b/test/compiler/solc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compileSolidity } from "../../src/compiler/solc";
+import { compileSolidity, compileSolidityBatch } from "../../src/compiler/solc";
 import type { SkittlesConfig } from "../../src/types";
 import { defaultConfig } from "../fixtures";
 


### PR DESCRIPTION
Closes #244

## Problem

`src/compiler/solc.ts` has two functions that share most of their logic:

- `compileSolidity` (lines 21–85) — compiles a single Solidity source
- `compileSolidityBatch` (lines 105–149) — compiles multiple sources

Both construct similar solc input JSON, call `solc.compile()`, and process errors/output in nearly identical ways. The error iteration logic (lines 54–59 vs 137–144) is also duplicated.

## Suggested Fix

Extract a shared core function (e.g. `runSolc`) that handles input construction, compilation, and error processing. Both public functions become thin wrappers:

```typescript
function runSolc(sources: Record<string, string>, config: SkittlesConfig): SolcRawOutput { ... }

export function compileSolidity(source: string, config: SkittlesConfig): SolcResult {
  const raw = runSolc({ "Contracts.sol": source }, config);
  // extract single contract result
}

export function compileSolidityBatch(sources: Record<string, string>, config: SkittlesConfig): SolcBatchResult {
  const raw = runSolc(sources, config);
  // extract per-file results
}
```

Also, `"Contracts.sol"` is a magic string that should be a named constant.