### PR TITLE
Support TypeScript private class fields (#field syntax)

### DIFF
--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -262,8 +262,10 @@ export function parseClass(
   const varTypes = new Map<string, SkittlesType>();
   for (const member of propertyMembers) {
     const name =
-      member.name && ts.isIdentifier(member.name)
-        ? member.name.text
+      member.name && (ts.isIdentifier(member.name) || ts.isPrivateIdentifier(member.name))
+        ? ts.isPrivateIdentifier(member.name)
+          ? member.name.text.replace(/^#/, "")
+          : member.name.text
         : "unknown";
     const type: SkittlesType = member.type
       ? parseType(member.type)
@@ -806,8 +808,13 @@ export function tryParseError(
 }
 
 export function parseProperty(node: ts.PropertyDeclaration): SkittlesVariable {
+  const isPrivateField = node.name && ts.isPrivateIdentifier(node.name);
   const name =
-    node.name && ts.isIdentifier(node.name) ? node.name.text : "unknown";
+    node.name && (ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name))
+      ? isPrivateField
+        ? node.name.text.replace(/^#/, "")
+        : node.name.text
+      : "unknown";
 
   validateReservedName("Property name", name);
 
@@ -815,7 +822,7 @@ export function parseProperty(node: ts.PropertyDeclaration): SkittlesVariable {
     ? parseType(node.type)
     : { kind: SkittlesTypeKind.Uint256 };
 
-  const visibility = getVisibility(node.modifiers);
+  const visibility = isPrivateField ? "private" as const : getVisibility(node.modifiers);
   const isStatic = hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword);
   const isReadonly = hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword);
   const constant = isStatic && isReadonly;

--- a/src/compiler/expression-parser.ts
+++ b/src/compiler/expression-parser.ts
@@ -99,7 +99,9 @@ export function parseExpression(node: ts.Expression): Expression {
 
   if (ts.isPropertyAccessExpression(node)) {
     const object = parseExpression(node.expression);
-    const property = node.name.text;
+    const property = ts.isPrivateIdentifier(node.name)
+      ? node.name.text.replace(/^#/, "")
+      : node.name.text;
 
     // string.length → bytes(str).length
     if (property === "length" && isStringExpr(object)) {

--- a/test/compiler/parser.test.ts
+++ b/test/compiler/parser.test.ts
@@ -293,6 +293,38 @@ describe("parse", () => {
     expect(vars[2].visibility).toBe("internal");
   });
 
+  it("should parse private class fields (#field syntax)", () => {
+    const contracts = parse(
+      `class T {
+        #balance: number = 0;
+        #name: string = "";
+      }`,
+      "test.ts"
+    );
+    const vars = contracts[0].variables;
+    expect(vars[0].name).toBe("balance");
+    expect(vars[0].visibility).toBe("private");
+    expect(vars[1].name).toBe("name");
+    expect(vars[1].visibility).toBe("private");
+  });
+
+  it("should parse this.#field access in method bodies", () => {
+    const contracts = parse(
+      `class T {
+        #value: number = 0;
+        getValue(): number {
+          return this.#value;
+        }
+      }`,
+      "test.ts"
+    );
+    const fn = contracts[0].functions[0];
+    expect(fn.body[0].kind).toBe("return");
+    const ret = fn.body[0] as { kind: "return"; value: any };
+    expect(ret.value.kind).toBe("property-access");
+    expect(ret.value.property).toBe("value");
+  });
+
   it("should parse readonly as immutable", () => {
     const contracts = parse(
       `class T { public readonly x: number = 42; }`,


### PR DESCRIPTION
Closes #192

## Description

TypeScript supports private class fields using the `#` prefix syntax (ECMAScript private fields). These are a stricter form of privacy than the `private` keyword. Since Skittles already maps `private` to `internal` in Solidity, it would be natural to also support `#field` syntax.

## Example

```typescript
export class Token {
  #balances: Record<address, number> = {};
  #totalSupply: number = 0;

  balanceOf(account: address): number {
    return this.#balances[account];
  }
}
```

## Why

Many TypeScript developers prefer the `#` syntax for private fields because it's the standard ECMAScript way. Supporting it would make Skittles feel more natural for modern TypeScript codebases.

## Suggested Behavior

Compile `#field` to `internal` visibility (same as `private`), stripping the `#` prefix in the generated Solidity field name.