### PR TITLE
Add error recovery: report multiple compilation errors instead of stopping at first

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -30,9 +30,16 @@ async function executeCompilation(
       return true;
     } else {
       spinner.fail("Compilation failed");
-      for (const error of result.errors) {
-        logError(error);
+
+      if (result.failedFiles > 0) {
+        logError(`${result.failedFiles} file(s) failed to compile`);
       }
+      if (result.artifacts.length > 0) {
+        logSuccess(
+          `${result.artifacts.length} contract(s) compiled successfully`
+        );
+      }
+
       if (options?.exitOnError) {
         process.exit(1);
       }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -42,6 +42,7 @@ export interface CompilationResult {
   artifacts: BuildArtifact[];
   errors: string[];
   warnings: string[];
+  failedFiles: number;
 }
 
 // ============================================================
@@ -404,7 +405,8 @@ function parseContracts(
     functions: SkittlesFunction[];
     constants: Map<string, Expression>;
   },
-  errors: string[]
+  errors: string[],
+  failedFiles: Set<string>
 ): {
   parsedFiles: ParsedFile[];
   cachedFiles: CachedFile[];
@@ -463,7 +465,8 @@ function parseContracts(
       const message =
         err instanceof Error ? err.message : "Unknown error occurred";
       errors.push(`${relativePath}: ${message}`);
-      logError(`Failed to compile ${relativePath}: ${message}`);
+      failedFiles.add(relativePath);
+      logError(`${relativePath}: ${message}`);
     }
   }
 
@@ -604,6 +607,7 @@ function generateOutput(
   outputDir: string,
   artifacts: BuildArtifact[],
   errors: string[],
+  failedFiles: Set<string>,
   newCache: CompilationCache
 ): void {
   // Resolve interface mutabilities from implementing contracts
@@ -803,7 +807,8 @@ function generateOutput(
       const message =
         err instanceof Error ? err.message : "Unknown error occurred";
       errors.push(`${relativePath}: ${message}`);
-      logError(`Failed to compile ${relativePath}: ${message}`);
+      failedFiles.add(relativePath);
+      logError(`${relativePath}: ${message}`);
     }
   }
 }
@@ -845,6 +850,7 @@ export async function compile(
   const artifacts: BuildArtifact[] = [];
   const errors: string[] = [];
   const warnings: string[] = [];
+  const failedFiles = new Set<string>();
 
   // Phase 1: Discover source files (user + stdlib)
   const state: PreScanState = {
@@ -864,7 +870,7 @@ export async function compile(
 
   if (userSourceFiles.length === 0) {
     logInfo("No TypeScript contract files found.");
-    return { success: true, artifacts, errors, warnings: [] };
+    return { success: true, artifacts, errors, warnings: [], failedFiles: 0 };
   }
 
   logInfo(`Found ${userSourceFiles.length} contract file(s)`);
@@ -896,7 +902,8 @@ export async function compile(
     configHash,
     externalTypes,
     externalFunctions,
-    errors
+    errors,
+    failedFiles
   );
 
   // Phase 5: Analyze contracts (mutability propagation + warnings)
@@ -916,6 +923,7 @@ export async function compile(
     outputDir,
     artifacts,
     errors,
+    failedFiles,
     newCache
   );
 
@@ -927,6 +935,7 @@ export async function compile(
     artifacts,
     errors,
     warnings,
+    failedFiles: failedFiles.size,
   };
 }
 

--- a/test/compiler/cache.test.ts
+++ b/test/compiler/cache.test.ts
@@ -496,6 +496,106 @@ describe("incremental compilation cache", () => {
     expect(stakingArtifact!.solidity).toContain("enum VaultStatus {");
   });
 
+  it("should continue compiling other files when one file has errors", async () => {
+    // Write one valid contract and one invalid contract
+    writeContract(
+      projectRoot,
+      "Good.ts",
+      `
+      class Good {
+        public value: number = 0;
+        public setValue(v: number): void {
+          this.value = v;
+        }
+      }
+    `
+    );
+
+    writeContract(
+      projectRoot,
+      "Bad.ts",
+      `
+      class Bad {
+        public x: bigint = 0;
+      }
+    `
+    );
+
+    const result = await compile(projectRoot, defaultConfig);
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.failedFiles).toBeGreaterThan(0);
+
+    // The valid contract should still have been compiled successfully
+    const goodArtifact = result.artifacts.find(
+      (a) => a.contractName === "Good"
+    );
+    expect(goodArtifact).toBeDefined();
+  });
+
+  it("should report failedFiles count of zero on success", async () => {
+    writeContract(
+      projectRoot,
+      "Counter.ts",
+      `
+      class Counter {
+        public count: number = 0;
+        public increment(): void {
+          this.count = this.count + 1;
+        }
+      }
+    `
+    );
+
+    const result = await compile(projectRoot, defaultConfig);
+    expect(result.success).toBe(true);
+    expect(result.failedFiles).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should report multiple errors from multiple files", async () => {
+    writeContract(
+      projectRoot,
+      "Bad1.ts",
+      `
+      class Bad1 {
+        public x: bigint = 0;
+      }
+    `
+    );
+
+    writeContract(
+      projectRoot,
+      "Bad2.ts",
+      `
+      class Bad2 {
+        public y: bigint = 0;
+      }
+    `
+    );
+
+    writeContract(
+      projectRoot,
+      "Good.ts",
+      `
+      class Good {
+        public value: number = 0;
+      }
+    `
+    );
+
+    const result = await compile(projectRoot, defaultConfig);
+    expect(result.success).toBe(false);
+    expect(result.failedFiles).toBe(2);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+
+    // The valid contract should still compile
+    const goodArtifact = result.artifacts.find(
+      (a) => a.contractName === "Good"
+    );
+    expect(goodArtifact).toBeDefined();
+  });
+
   it("should generate import statement for cross-file contract inheritance", async () => {
     writeContract(
       projectRoot,


### PR DESCRIPTION
Closes #128

## Description

Currently when the Skittles compiler encounters an error (e.g., unsupported TypeScript syntax), it appears to stop processing. It would be more developer-friendly to collect and report all errors at once, similar to how the TypeScript compiler reports multiple errors.

## Expected Behavior

```
🍬 Skittles
ℹ Found 5 contract file(s)
✗ contracts/Foo.ts: Unsupported syntax: typeof operator (line 12)
✗ contracts/Foo.ts: Unknown type: bigint (line 15)
✗ contracts/Bar.ts: Cannot use 'this' outside of a class (line 3)
✔ contracts/Baz.ts compiled successfully
✔ contracts/Token.ts compiled successfully

✗ 2 file(s) failed to compile
✓ 2 contract(s) compiled successfully
```

## Why This Matters

When developing multiple contracts, hitting one error and having to fix it before seeing all other errors is frustrating. Batch error reporting lets developers fix multiple issues at once.

## Version
Skittles 1.3.0