### PR TITLE
Support Solidity NatSpec comments from TypeScript JSDoc comments

### DIFF
--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -12,6 +12,7 @@ import {
   type SkittlesInterfaceFunction,
   type Statement,
   type Expression,
+  type NatSpec,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 import {
@@ -60,6 +61,7 @@ export function parseStandaloneFunction(
     ? parseBlock(node.body, localVarTypes, eventNames)
     : [];
   const stateMutability = inferStateMutability(body, localVarTypes, parameters);
+  const natspec = parseNatSpec(node);
 
   return {
     name,
@@ -71,6 +73,7 @@ export function parseStandaloneFunction(
     isOverride: false,
     body,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -689,6 +692,8 @@ export function parseClass(
     contractCustomErrors.push({ name: ie.name, parameters: ie.parameters });
   }
 
+  const natspec = parseNatSpec(node);
+
   return {
     name,
     sourcePath: filePath,
@@ -705,6 +710,7 @@ export function parseClass(
     sourceLine: getSourceLine(node),
     neededArrayHelpers:
       ctx.neededArrayHelpers.size > 0 ? [...ctx.neededArrayHelpers] : undefined,
+    natspec,
   };
 }
 
@@ -721,13 +727,15 @@ export function tryParseEvent(
   const name =
     node.name && ts.isIdentifier(node.name) ? node.name.text : "Unknown";
 
+  const natspec = parseNatSpec(node);
+
   if (!node.type.typeArguments || node.type.typeArguments.length === 0) {
-    return { name, parameters: [], sourceLine: getSourceLine(node) };
+    return { name, parameters: [], sourceLine: getSourceLine(node), natspec };
   }
 
   const typeArg = node.type.typeArguments[0];
   if (!ts.isTypeLiteralNode(typeArg)) {
-    return { name, parameters: [], sourceLine: getSourceLine(node) };
+    return { name, parameters: [], sourceLine: getSourceLine(node), natspec };
   }
 
   const parameters: SkittlesParameter[] = [];
@@ -760,7 +768,7 @@ export function tryParseEvent(
     }
   }
 
-  return { name, parameters, sourceLine: getSourceLine(node) };
+  return { name, parameters, sourceLine: getSourceLine(node), natspec };
 }
 
 // ============================================================
@@ -840,6 +848,8 @@ export function parseProperty(node: ts.PropertyDeclaration): SkittlesVariable {
     }
   }
 
+  const natspec = parseNatSpec(node);
+
   return {
     name,
     type,
@@ -848,6 +858,7 @@ export function parseProperty(node: ts.PropertyDeclaration): SkittlesVariable {
     constant,
     initialValue,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -887,6 +898,7 @@ export function parseMethod(
 
   const isOverride = hasModifier(node.modifiers, ts.SyntaxKind.OverrideKeyword);
   const isVirtual = !isOverride;
+  const natspec = parseNatSpec(node);
 
   return {
     name,
@@ -899,6 +911,7 @@ export function parseMethod(
     isAbstract: isAbstractMethod ? true : undefined,
     body,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -1071,6 +1084,7 @@ export function parseGetAccessor(
 
   const isOverride = hasModifier(node.modifiers, ts.SyntaxKind.OverrideKeyword);
   const isVirtual = !isOverride;
+  const natspec = parseNatSpec(node);
 
   return {
     name,
@@ -1082,6 +1096,7 @@ export function parseGetAccessor(
     isOverride,
     body,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -1113,6 +1128,7 @@ export function parseSetAccessor(
 
   const isOverride = hasModifier(node.modifiers, ts.SyntaxKind.OverrideKeyword);
   const isVirtual = !isOverride;
+  const natspec = parseNatSpec(node);
 
   return {
     name,
@@ -1124,6 +1140,7 @@ export function parseSetAccessor(
     isOverride,
     body,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -1169,6 +1186,7 @@ export function parseArrowProperty(
   const stateMutability = inferStateMutability(body, localVarTypes, parameters);
   const isOverride = hasModifier(node.modifiers, ts.SyntaxKind.OverrideKeyword);
   const isVirtual = !isOverride;
+  const natspec = parseNatSpec(node);
 
   return {
     name,
@@ -1180,6 +1198,7 @@ export function parseArrowProperty(
     isOverride,
     body,
     sourceLine: getSourceLine(node),
+    natspec,
   };
 }
 
@@ -1216,6 +1235,100 @@ export function parseParameter(
     param.defaultValue = parseExpression(node.initializer);
   }
   return param;
+}
+
+// ============================================================
+// JSDoc → NatSpec extraction
+// ============================================================
+
+export function parseNatSpec(node: ts.Node): NatSpec | undefined {
+  const jsDocs = (node as { jsDoc?: ts.JSDoc[] }).jsDoc;
+  if (!jsDocs || jsDocs.length === 0) return undefined;
+
+  const natspec: NatSpec = {};
+  let hasContent = false;
+
+  for (const doc of jsDocs) {
+    // Extract the main comment text as @notice if no explicit @notice tag exists
+    if (doc.comment) {
+      const commentText =
+        typeof doc.comment === "string"
+          ? doc.comment
+          : doc.comment
+              .map((part: ts.JSDocComment) =>
+                ts.isJSDocLink(part) || ts.isJSDocLinkCode(part) || ts.isJSDocLinkPlain(part)
+                  ? part.text
+                  : part.text
+              )
+              .join("");
+      if (commentText.trim()) {
+        // Only use main comment as notice if no explicit @notice tag
+        const hasNoticeTag = doc.tags?.some(
+          (tag) => tag.tagName.text === "notice"
+        );
+        if (!hasNoticeTag) {
+          natspec.notice = commentText.trim();
+          hasContent = true;
+        }
+      }
+    }
+
+    if (doc.tags) {
+      for (const tag of doc.tags) {
+        const tagName = tag.tagName.text;
+        const tagComment = tag.comment
+          ? typeof tag.comment === "string"
+            ? tag.comment
+            : tag.comment
+                .map((part: ts.JSDocComment) =>
+                  ts.isJSDocLink(part) || ts.isJSDocLinkCode(part) || ts.isJSDocLinkPlain(part)
+                    ? part.text
+                    : part.text
+                )
+                .join("")
+          : "";
+
+        switch (tagName) {
+          case "title":
+            natspec.title = tagComment.trim();
+            hasContent = true;
+            break;
+          case "author":
+            natspec.author = tagComment.trim();
+            hasContent = true;
+            break;
+          case "notice":
+            natspec.notice = tagComment.trim();
+            hasContent = true;
+            break;
+          case "dev":
+            natspec.dev = tagComment.trim();
+            hasContent = true;
+            break;
+          case "param":
+            if (ts.isJSDocParameterTag(tag) && tag.name) {
+              const paramName = ts.isIdentifier(tag.name)
+                ? tag.name.text
+                : tag.name.getText();
+              if (!natspec.params) natspec.params = [];
+              natspec.params.push({
+                name: paramName,
+                description: tagComment.trim(),
+              });
+              hasContent = true;
+            }
+            break;
+          case "returns":
+          case "return":
+            natspec.returns = tagComment.trim();
+            hasContent = true;
+            break;
+        }
+      }
+    }
+  }
+
+  return hasContent ? natspec : undefined;
 }
 
 // ============================================================

--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -16,6 +16,7 @@ import {
   type SkittlesParameter,
   type SourceMapping,
   type SolidityConfig,
+  type NatSpec,
 } from "../types/index.ts";
 import { DEFAULT_CONFIG } from "../config/defaults.ts";
 import {
@@ -944,6 +945,43 @@ const getFunctionKey = (f: SkittlesFunction): string => {
   return `${f.name}(${paramTypes})`;
 };
 
+function emitNatSpecTag(
+  lines: string[],
+  indent: string,
+  tag: string,
+  text: string
+): void {
+  const textLines = text.split("\n");
+  lines.push(`${indent}/// @${tag} ${textLines[0]}`);
+  for (let i = 1; i < textLines.length; i++) {
+    const trimmed = textLines[i].trim();
+    if (trimmed) {
+      lines.push(`${indent}/// ${trimmed}`);
+    } else {
+      lines.push(`${indent}///`);
+    }
+  }
+}
+
+function generateNatSpecLines(
+  natspec: NatSpec | undefined,
+  indent: string = ""
+): string[] {
+  if (!natspec) return [];
+  const lines: string[] = [];
+  if (natspec.title) emitNatSpecTag(lines, indent, "title", natspec.title);
+  if (natspec.author) emitNatSpecTag(lines, indent, "author", natspec.author);
+  if (natspec.notice) emitNatSpecTag(lines, indent, "notice", natspec.notice);
+  if (natspec.dev) emitNatSpecTag(lines, indent, "dev", natspec.dev);
+  if (natspec.params) {
+    for (const p of natspec.params) {
+      emitNatSpecTag(lines, indent, `param ${p.name}`, p.description);
+    }
+  }
+  if (natspec.returns) emitNatSpecTag(lines, indent, "return", natspec.returns);
+  return lines;
+}
+
 const hasAncestorOrigin = (
   origins: Set<string> | undefined,
   ancestors: Set<string>
@@ -965,6 +1003,8 @@ function generateContractBody(
   const inheritance =
     contract.inherits.length > 0 ? ` is ${contract.inherits.join(", ")}` : "";
   const abstractPrefix = contract.isAbstract ? "abstract " : "";
+  const contractNatSpec = generateNatSpecLines(contract.natspec);
+  for (const line of contractNatSpec) parts.push(line);
   parts.push(`${abstractPrefix}contract ${contract.name}${inheritance} {`);
 
   const addOrigin = (map: Map<string, Set<string>>, key: string): void => {
@@ -988,6 +1028,8 @@ function generateContractBody(
   for (const ce of contract.customErrors ?? []) {
     if (hasAncestorOrigin(definitionOrigins.get(ce.name), ancestors)) continue;
     addOrigin(definitionOrigins, ce.name);
+    const errorNatSpec = generateNatSpecLines(ce.natspec, "    ");
+    for (const line of errorNatSpec) parts.push(line);
     const params = ce.parameters
       .map((p) => `${generateType(p.type)} ${p.name}`)
       .join(", ");
@@ -1007,6 +1049,8 @@ function generateContractBody(
   }
 
   for (const e of contract.events) {
+    const eventNatSpec = generateNatSpecLines(e.natspec, "    ");
+    for (const line of eventNatSpec) parts.push(line);
     parts.push(`    ${generateEventDecl(e)}`);
   }
 
@@ -1042,6 +1086,8 @@ function generateStateVariables(
   functionsToEmit: SkittlesFunction[];
 } {
   for (const v of contract.variables) {
+    const varNatSpec = generateNatSpecLines(v.natspec, "    ");
+    for (const line of varNatSpec) parts.push(line);
     parts.push(`    ${generateVariable(v)}`);
   }
 
@@ -1737,8 +1783,10 @@ function expandDefaultParamOverloads(f: SkittlesFunction): SkittlesFunction[] {
 }
 
 function generateFunction(f: SkittlesFunction): string {
+  const natspecLines = generateNatSpecLines(f.natspec, "    ");
+
   if (f.name === "receive") {
-    const lines: string[] = [];
+    const lines: string[] = [...natspecLines];
     lines.push("    receive() external payable {");
     for (const s of f.body) {
       lines.push(generateStatement(s, "        "));
@@ -1748,7 +1796,7 @@ function generateFunction(f: SkittlesFunction): string {
   }
 
   if (f.name === "fallback") {
-    const lines: string[] = [];
+    const lines: string[] = [...natspecLines];
     lines.push("    fallback() external payable {");
     for (const s of f.body) {
       lines.push(generateStatement(s, "        "));
@@ -1787,7 +1835,7 @@ function generateFunction(f: SkittlesFunction): string {
     }
   }
 
-  const lines: string[] = [];
+  const lines: string[] = [...natspecLines];
   if (f.isAbstract) {
     lines.push(
       `    function ${f.name}(${params}) ${vis}${mut}${virtOverride}${returns};`

--- a/src/types/ir.ts
+++ b/src/types/ir.ts
@@ -33,6 +33,19 @@ export type Visibility = "public" | "private" | "internal" | "external";
 export type StateMutability = "pure" | "view" | "nonpayable" | "payable";
 
 // ============================================================
+// NatSpec documentation
+// ============================================================
+
+export interface NatSpec {
+  title?: string;
+  author?: string;
+  notice?: string;
+  dev?: string;
+  params?: { name: string; description: string }[];
+  returns?: string;
+}
+
+// ============================================================
 // Contract IR
 // ============================================================
 
@@ -61,6 +74,7 @@ export interface SkittlesEnum {
 export interface SkittlesCustomError {
   name: string;
   parameters: SkittlesParameter[];
+  natspec?: NatSpec;
 }
 
 export interface SkittlesContract {
@@ -78,6 +92,7 @@ export interface SkittlesContract {
   isAbstract?: boolean;
   sourceLine?: number;
   neededArrayHelpers?: string[];
+  natspec?: NatSpec;
 }
 
 export interface SkittlesVariable {
@@ -89,6 +104,7 @@ export interface SkittlesVariable {
   isOverride?: boolean;
   initialValue?: Expression;
   sourceLine?: number;
+  natspec?: NatSpec;
 }
 
 export interface SkittlesFunction {
@@ -102,6 +118,7 @@ export interface SkittlesFunction {
   isAbstract?: boolean;
   body: Statement[];
   sourceLine?: number;
+  natspec?: NatSpec;
 }
 
 export interface SkittlesConstructor {
@@ -114,6 +131,7 @@ export interface SkittlesEvent {
   name: string;
   parameters: SkittlesParameter[];
   sourceLine?: number;
+  natspec?: NatSpec;
 }
 
 export interface SkittlesParameter {


### PR DESCRIPTION
Closes #131

## Description

Solidity supports NatSpec comments for documenting contracts, functions, events, and errors. These are used by tools like Etherscan, IDEs, and documentation generators. Skittles should compile TypeScript JSDoc comments into Solidity NatSpec.

## Example

TypeScript input:
```typescript
/**
 * @title Simple Token
 * @notice A basic ERC20-like token
 * @author Skittles Team
 */
export class Token {
  /**
   * @notice Transfer tokens to another address
   * @param to The recipient address
   * @param amount The amount to transfer
   * @return Whether the transfer succeeded
   */
  public transfer(to: address, amount: number): boolean {
    // ...
    return true;
  }
}
```

Solidity output:
```solidity
/// @title Simple Token
/// @notice A basic ERC20-like token
/// @author Skittles Team
contract Token {
    /// @notice Transfer tokens to another address
    /// @param to The recipient address
    /// @param amount The amount to transfer
    /// @return Whether the transfer succeeded
    function transfer(address to, uint256 amount) public virtual returns (bool) {
        // ...
        return true;
    }
}
```

## Why This Matters

NatSpec documentation is essential for:
- Etherscan verification (shows docs on the contract page)
- Auto-generated documentation
- IDE tooltips for contract consumers
- Audit reports

## Version
Skittles 1.3.0