### PR TITLE
Math.sqrt() returns incorrect result for small values (e.g. sqrt(2) returns 2 instead of 1)

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -57,7 +57,7 @@ const HELPER_REGISTRY: Array<{ name: string; lines: () => string[] }> = [
     lines: () => [
       "    function _sqrt(uint256 x) internal pure returns (uint256) {",
       "        if (x == 0) return 0;",
-      "        uint256 z = (x >> 1) + 1;",
+      "        uint256 z = (x + 1) / 2;",
       "        uint256 y = x;",
       "        while (z < y) {",
       "            y = z;",

--- a/test/compiler/integration-builtins.test.ts
+++ b/test/compiler/integration-builtins.test.ts
@@ -317,6 +317,7 @@ describe("integration: built-in functions", () => {
     expect(solidity).toContain(
       "function _sqrt(uint256 x) internal pure returns (uint256)"
     );
+    expect(solidity).toContain("uint256 z = (x + 1) / 2;");
   });
 
   it("should wrap ecrecover v argument in uint8() cast", () => {


### PR DESCRIPTION
Closes #324

## Description

The generated `_sqrt` helper function returns incorrect results for small input values. For example, `Math.sqrt(2)` returns `2` instead of `1`.

## Root Cause

The Babylonian method implementation uses `z = (x >> 1) + 1` as the initial guess. For `x = 2`:
- `z = (2 >> 1) + 1 = 2`
- `y = 2`
- The while loop condition `z < y` evaluates to `2 < 2 = false`
- The loop never executes, and `y = 2` is returned

The initial guess should be `z = (x + 1) / 2` instead of `z = (x >> 1) + 1`, which for x = 2 would give z = 1, allowing the loop to correctly converge.

## Generated Solidity

```solidity
function _sqrt(uint256 x) internal pure returns (uint256) {
    if (x == 0) return 0;
    uint256 z = (x >> 1) + 1;  // Bug: for x=2, z=2, loop never runs
    uint256 y = x;
    while (z < y) {
        y = z;
        z = (x / z + z) / 2;
    }
    return y;
}
```

## Expected Behavior

- `Math.sqrt(0)` = 0
- `Math.sqrt(1)` = 1
- `Math.sqrt(2)` = 1
- `Math.sqrt(3)` = 1
- `Math.sqrt(4)` = 2

## Actual Behavior

- `Math.sqrt(0)` = 0
- `Math.sqrt(1)` = 1
- `Math.sqrt(2)` = 2 (WRONG)
- `Math.sqrt(3)` = 2 (likely WRONG)
- `Math.sqrt(4)` = 2

## Suggested Fix

Replace `uint256 z = (x >> 1) + 1;` with `uint256 z = (x + 1) / 2;` or add a final check `return y * y <= x ? y : y - 1;`

## Version

skittles 1.5.0