### PR TITLE
Pre-scan warning for imported enum type in type guard function parameter

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -23,6 +23,7 @@ import {
   collectFunctions,
   collectClassNames,
 } from "./parser.ts";
+import { ctx } from "./parser-context.ts";
 import {
   generateSolidity,
   generateSolidityFile,
@@ -222,6 +223,12 @@ function preScanContracts(
           state.interfaceOriginFile.set(name, baseName);
         }
       }
+
+      // Seed the parser context with types collected so far (from this file
+      // and previously scanned files) so that standalone functions referencing
+      // imported enum/struct types can be parsed without spurious errors.
+      ctx.knownStructs = new Map(state.globalStructs);
+      ctx.knownEnums = new Map(state.globalEnums);
 
       const { functions, constants } = collectFunctions(source, filePath);
       for (const fn of functions) {

--- a/test/compiler/integration-cross-file.test.ts
+++ b/test/compiler/integration-cross-file.test.ts
@@ -4,6 +4,7 @@ import {
   collectTypes,
   collectFunctions,
 } from "../../src/compiler/parser";
+import { ctx } from "../../src/compiler/parser-context";
 import {
   generateSolidity,
 } from "../../src/compiler/codegen";
@@ -376,6 +377,39 @@ describe("integration: cross file function imports", () => {
     );
     expect(solidity).toContain("return add(x, y);");
     expect(solidity).toContain("return multiply(x, y);");
+  });
+});
+
+// ============================================================
+// Standalone functions referencing imported enum types
+// ============================================================
+
+describe("integration: cross file enum in standalone function parameter", () => {
+  it("should not throw when collectFunctions parses a function with an imported enum parameter", () => {
+    const typesSource = `
+      enum VaultStatus { Active, Paused, Stopped }
+    `;
+    const functionSource = `
+      function isActive(s: VaultStatus): boolean {
+        return s == 0;
+      }
+    `;
+
+    // Collect enum types from the types file first
+    const { structs, enums } = collectTypes(typesSource, "types.ts");
+
+    // Seed the parser context with the collected enums (simulating pre-scan)
+    ctx.knownEnums = new Map(enums);
+    ctx.knownStructs = new Map(structs);
+
+    // collectFunctions should not throw for the imported enum type
+    expect(() => {
+      collectFunctions(functionSource, "utils.ts");
+    }).not.toThrow();
+
+    const { functions } = collectFunctions(functionSource, "utils.ts");
+    expect(functions).toHaveLength(1);
+    expect(functions[0].name).toBe("isActive");
   });
 });
 


### PR DESCRIPTION
Closes #325

## Description

When defining a type guard function that uses an imported enum type as a parameter, the pre-scan phase emits a spurious warning:

```
Pre-scan failed for EdgeCaseTests.ts: Unsupported type reference: "VaultStatus"
```

The contract still compiles successfully, but the warning is confusing since enums are a documented and supported type.

## Steps to Reproduce

```typescript
import { VaultStatus } from "./types";

function isActive(s: VaultStatus): s is VaultStatus.Active {
  return s == VaultStatus.Active;
}
```

Where `types.ts` exports:
```typescript
export enum VaultStatus { Active, Paused, Stopped }
```

## Expected Behavior

No warning should be emitted. The enum type `VaultStatus` is a supported type.

## Actual Behavior

```
Pre-scan failed for EdgeCaseTests.ts: Unsupported type reference: "VaultStatus"
```

The contract still compiles successfully despite the warning.

## Version

skittles 1.5.0