### PR TITLE
for...in loop over enum generates unused local variable warning in Solidity

### DIFF
--- a/src/compiler/statement-parser.ts
+++ b/src/compiler/statement-parser.ts
@@ -10,6 +10,7 @@ import {
   type SwitchCase,
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
+import { walkStatements } from "./walker.ts";
 import {
   getSourceLine,
   setupStringTracking,
@@ -912,17 +913,31 @@ export function parseStatement(
         ctx.currentStringNames = previousStringNames;
       }
 
-      // Prepend: EnumType item = EnumType(_i);
-      const itemDecl: Statement = {
-        kind: "variable-declaration",
-        name: itemName,
-        type: { kind: SkittlesTypeKind.Enum, structName: enumName },
-        initializer: {
-          kind: "call",
-          callee: { kind: "identifier", name: enumName },
-          args: [{ kind: "identifier", name: indexName }],
+      // Check if the loop variable is actually used in the loop body
+      let itemUsed = false;
+      walkStatements(innerBody, {
+        visitExpression(expr) {
+          if (expr.kind === "identifier" && expr.name === itemName) {
+            itemUsed = true;
+          }
         },
-      };
+      });
+
+      // Prepend: EnumType item = EnumType(_i); only if used
+      const bodyStatements: Statement[] = [];
+      if (itemUsed) {
+        bodyStatements.push({
+          kind: "variable-declaration",
+          name: itemName,
+          type: { kind: SkittlesTypeKind.Enum, structName: enumName },
+          initializer: {
+            kind: "call",
+            callee: { kind: "identifier", name: enumName },
+            args: [{ kind: "identifier", name: indexName }],
+          },
+        });
+      }
+      bodyStatements.push(...innerBody);
 
       return {
         kind: "for",
@@ -944,7 +959,7 @@ export function parseStatement(
           operand: { kind: "identifier", name: indexName },
           prefix: false,
         },
-        body: [itemDecl, ...innerBody],
+        body: bodyStatements,
         sourceLine: getSourceLine(node),
       };
     }

--- a/test/compiler/integration-control-flow.test.ts
+++ b/test/compiler/integration-control-flow.test.ts
@@ -357,7 +357,7 @@ describe("integration: for...in enum loops", () => {
     expect(solidity).toContain(
       "for (uint256 __sk_i_status = 0; (__sk_i_status < 3); __sk_i_status++)"
     );
-    expect(solidity).toContain("Status status = Status(__sk_i_status);");
+    expect(solidity).not.toContain("Status status = Status(__sk_i_status);");
   });
 
   it("should compile for...in with enum body using the variable", () => {
@@ -381,8 +381,50 @@ describe("integration: for...in enum loops", () => {
     );
     const solidity = generateSolidity(contracts[0]);
     expect(solidity).toContain("__sk_i_c");
-    expect(solidity).toContain("Color c = Color(__sk_i_c);");
+    expect(solidity).not.toContain("Color c = Color(__sk_i_c);");
     expect(solidity).toContain("count += 1;");
+  });
+
+  it("should include enum cast variable when loop variable is used in body", () => {
+    const { errors, solidity } = compileTS(`
+      enum Priority { Low, Medium, High, Critical }
+
+      class Example {
+        public priorities: Priority[] = [];
+
+        public collectPriorities(): void {
+          for (const p in Priority) {
+            this.priorities.push(p);
+          }
+        }
+      }
+    `);
+    expect(errors).toHaveLength(0);
+    expect(solidity).toContain(
+      "for (uint256 __sk_i_p = 0; (__sk_i_p < 4); __sk_i_p++)"
+    );
+    expect(solidity).toContain("Priority p = Priority(__sk_i_p);");
+  });
+
+  it("should omit enum cast variable when loop variable is unused", () => {
+    const { errors, solidity } = compileTS(`
+      enum Priority { Low, Medium, High, Critical }
+
+      class Example {
+        public countEnumMembers(): number {
+          let enumCount: number = 0;
+          for (const p in Priority) {
+            enumCount++;
+          }
+          return enumCount;
+        }
+      }
+    `);
+    expect(errors).toHaveLength(0);
+    expect(solidity).toContain(
+      "for (uint256 __sk_i_p = 0; (__sk_i_p < 4); __sk_i_p++)"
+    );
+    expect(solidity).not.toContain("Priority p = Priority(__sk_i_p);");
   });
 });
 


### PR DESCRIPTION
Closes #326

## Description

When using `for...in` to iterate over an enum, the generated Solidity code creates a local variable for the enum member that is unused, triggering a Solidity compiler warning.

## Steps to Reproduce

```typescript
enum Priority { Low, Medium, High, Critical }

export class Example {
  public countEnumMembers(): number {
    let enumCount: number = 0;
    for (const p in Priority) {
      enumCount++;
    }
    return enumCount;
  }
}
```

## Generated Solidity

```solidity
for (uint256 __sk_i_p = 0; __sk_i_p < 4; __sk_i_p++) {
    Priority p = Priority(__sk_i_p);  // Warning: Unused local variable
    enumCount++;
}
```

## Expected Behavior

If the loop variable `p` is not referenced in the loop body, the local variable assignment should be omitted or suppressed.

## Actual Behavior

```
Warning: Unused local variable.
  --> EdgeCaseTests.sol:30:13
   |
30 |             Priority p = Priority(__sk_i_p);
   |             ^^^^^^^^^^
```

## Version

skittles 1.5.0