### PR TITLE
Mutability inference bug: mint() marked as view when extending ERC20Votes or ERC20Permit

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -68,6 +68,7 @@ interface CacheEntry {
   }[];
   resolvedMutabilities?: Record<string, Record<string, string>>;
   contractFunctions?: Record<string, Record<string, string>>;
+  contractInherits?: Record<string, string[]>;
 }
 
 interface CompilationCache {
@@ -496,27 +497,48 @@ function analyzeContracts(
     for (const c of contracts) allParsedContracts.set(c.name, c);
   }
 
-  // Include function mutabilities from cached contracts so that freshly
-  // parsed children can propagate mutability from cached parents.
+  // Include function mutabilities and inheritance info from cached contracts
+  // so that freshly parsed children can propagate mutability from cached parents.
   const cachedFnMutabilities = new Map<string, Map<string, string>>();
+  const cachedContractInherits = new Map<string, string[]>();
   for (const { cached } of cachedFiles) {
-    if (!cached.contractFunctions) continue;
-    for (const [contractName, fns] of Object.entries(
-      cached.contractFunctions
-    )) {
-      cachedFnMutabilities.set(contractName, new Map(Object.entries(fns)));
+    if (cached.contractFunctions) {
+      for (const [contractName, fns] of Object.entries(
+        cached.contractFunctions
+      )) {
+        cachedFnMutabilities.set(contractName, new Map(Object.entries(fns)));
+      }
+    }
+    if (cached.contractInherits) {
+      for (const [contractName, parents] of Object.entries(
+        cached.contractInherits
+      )) {
+        cachedContractInherits.set(contractName, parents);
+      }
     }
   }
 
   for (const { contracts } of parsedFiles) {
     for (const contract of contracts) {
       const parentMutabilities = new Map<string, string>();
-      for (const parentName of contract.inherits) {
+      // Traverse the full inheritance chain (not just direct parents)
+      // so that functions defined in grandparent contracts (e.g. _mint
+      // in ERC20 when extending ERC20Votes) are included.
+      const visited = new Set<string>();
+      const queue = [...contract.inherits];
+      while (queue.length > 0) {
+        const parentName = queue.pop()!;
+        if (visited.has(parentName)) continue;
+        visited.add(parentName);
         const parent = allParsedContracts.get(parentName);
         if (parent) {
           for (const fn of parent.functions) {
             if (!parentMutabilities.has(fn.name))
               parentMutabilities.set(fn.name, fn.stateMutability);
+          }
+          // Continue up the inheritance chain
+          for (const grandparent of parent.inherits) {
+            if (!visited.has(grandparent)) queue.push(grandparent);
           }
         } else {
           const cachedFns = cachedFnMutabilities.get(parentName);
@@ -524,6 +546,13 @@ function analyzeContracts(
             for (const [fnName, mut] of cachedFns) {
               if (!parentMutabilities.has(fnName))
                 parentMutabilities.set(fnName, mut);
+            }
+          }
+          // Continue up the inheritance chain for cached parents
+          const cachedParents = cachedContractInherits.get(parentName);
+          if (cachedParents) {
+            for (const grandparent of cachedParents) {
+              if (!visited.has(grandparent)) queue.push(grandparent);
             }
           }
         }
@@ -792,10 +821,12 @@ function generateOutput(
       );
 
       const contractFns: Record<string, Record<string, string>> = {};
+      const contractInheritsMap: Record<string, string[]> = {};
       for (const contract of contracts) {
         const fns: Record<string, string> = {};
         for (const fn of contract.functions) fns[fn.name] = fn.stateMutability;
         contractFns[contract.name] = fns;
+        contractInheritsMap[contract.name] = contract.inherits;
       }
 
       const cacheEntry: CacheEntry = {
@@ -806,6 +837,7 @@ function generateOutput(
         contracts: [],
         resolvedMutabilities,
         contractFunctions: contractFns,
+        contractInherits: contractInheritsMap,
       };
       writeFile(path.join(outputDir, "solidity", `${baseName}.sol`), solidity);
 

--- a/test/behavioral/stdlib.test.ts
+++ b/test/behavioral/stdlib.test.ts
@@ -1136,4 +1136,65 @@ export class MyToken extends ERC20 {
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("compiles a user contract extending ERC20Votes with mint() not marked as view", async () => {
+    const { compile } = await import("../../src/compiler/compiler");
+    const fs = await import("fs");
+    const path = await import("path");
+    const os = await import("os");
+
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "skittles-votes-mint-test-")
+    );
+    const contractsDir = path.join(tmpDir, "contracts");
+    fs.mkdirSync(contractsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(contractsDir, "GovToken.ts"),
+      `import { address, msg } from "skittles";
+import { ERC20Votes } from "skittles/contracts";
+
+export class GovToken extends ERC20Votes {
+  private _owner: address;
+
+  constructor() {
+    super("GovToken", "GOV");
+    this._owner = msg.sender;
+    this._mint(msg.sender, 1000000);
+  }
+
+  public mint(to: address, amount: number): void {
+    if (msg.sender != this._owner) {
+      throw new Error("Not owner");
+    }
+    this._mint(to, amount);
+  }
+}
+`
+    );
+
+    const result = await compile(tmpDir, {
+      typeCheck: false,
+      consoleLog: false,
+      contractsDir: "contracts",
+      outputDir: "artifacts",
+      cacheDir: "cache",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+
+    const solDir = path.join(tmpDir, "artifacts", "solidity");
+    const govTokenSol = fs.readFileSync(
+      path.join(solDir, "GovToken.sol"),
+      "utf-8"
+    );
+
+    // The mint function should NOT be marked as view since it calls _mint()
+    // which modifies state (this was the bug in issue #322)
+    expect(govTokenSol).not.toMatch(/function mint\([^)]*\)\s+public\s+view/);
+    expect(govTokenSol).toMatch(/function mint\([^)]*\)\s+public\s+virtual/);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
Closes #322

## Description

When a contract extends `ERC20Votes` or `ERC20Permit` from the standard library and defines a `mint()` function that calls `this._mint()`, the Skittles compiler incorrectly marks the generated Solidity function as `view` instead of state-modifying (no annotation).

## Steps to Reproduce

**GovToken.ts:**
```typescript
import { address, msg } from "skittles";
import { ERC20Votes } from "skittles/contracts";

export class GovToken extends ERC20Votes {
  private _owner: address;

  constructor() {
    super("GovToken", "GOV");
    this._owner = msg.sender;
    this._mint(msg.sender, 1000000);
  }

  public mint(to: address, amount: number): void {
    if (msg.sender != this._owner) {
      throw new Error("Not owner");
    }
    this._mint(to, amount);
  }
}
```

## Expected Behavior

The generated `mint` function should NOT have the `view` modifier since it calls `_mint()` which modifies state.

## Actual Behavior

Generated Solidity:
```solidity
function mint(address to, uint256 amount) public view virtual {
    require((msg.sender == _owner), "Not owner");
    _mint(to, amount);
}
```

This causes a Solidity compilation error:
```
TypeError: Function cannot be declared as view because this expression (potentially) modifies the state.
```

## Affects

- `ERC20Votes` (confirmed)
- `ERC20Permit` (confirmed)
- Likely any stdlib contract where `_mint` is defined in a parent contract

## Version

skittles 1.5.0