### PR TITLE
Enum return type: function returning number fails when returning enum state variable

### DIFF
--- a/src/compiler/codegen-context.ts
+++ b/src/compiler/codegen-context.ts
@@ -8,6 +8,12 @@ export interface CodegenContext {
   // Type name registries across all contracts in the current file
   allKnownEnumNames: Set<string>;
   allKnownInterfaceNames: Set<string>;
+
+  // Current function return type (set during function generation for enum→uint256 casts)
+  currentFunctionReturnType: import("../types/index.ts").SkittlesType | null;
+
+  // State variable names whose type is an enum (set per-contract)
+  currentEnumStateVarNames: Set<string>;
 }
 
 export function createCodegenContext(): CodegenContext {
@@ -16,6 +22,8 @@ export function createCodegenContext(): CodegenContext {
     currentNeededArrayHelpers: [],
     allKnownEnumNames: new Set(),
     allKnownInterfaceNames: new Set(),
+    currentFunctionReturnType: null,
+    currentEnumStateVarNames: new Set(),
   };
 }
 

--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -1000,6 +1000,13 @@ function generateContractBody(
   cctx.helpers = new Set();
   cctx.currentNeededArrayHelpers = contract.neededArrayHelpers ?? [];
 
+  // Track state variables whose type is an enum (for enum→uint256 return casts)
+  cctx.currentEnumStateVarNames = new Set(
+    contract.variables
+      .filter((v) => v.type.kind === SkittlesTypeKind.Enum)
+      .map((v) => v.name)
+  );
+
   const inheritance =
     contract.inherits.length > 0 ? ` is ${contract.inherits.join(", ")}` : "";
   const abstractPrefix = contract.isAbstract ? "abstract " : "";
@@ -1784,6 +1791,8 @@ function expandDefaultParamOverloads(f: SkittlesFunction): SkittlesFunction[] {
 
 function generateFunction(f: SkittlesFunction): string {
   const natspecLines = generateNatSpecLines(f.natspec, "    ");
+  const prevReturnType = cctx.currentFunctionReturnType;
+  cctx.currentFunctionReturnType = f.returnType;
 
   if (f.name === "receive") {
     const lines: string[] = [...natspecLines];
@@ -1792,6 +1801,7 @@ function generateFunction(f: SkittlesFunction): string {
       lines.push(generateStatement(s, "        "));
     }
     lines.push("    }");
+    cctx.currentFunctionReturnType = prevReturnType;
     return lines.join("\n");
   }
 
@@ -1802,6 +1812,7 @@ function generateFunction(f: SkittlesFunction): string {
       lines.push(generateStatement(s, "        "));
     }
     lines.push("    }");
+    cctx.currentFunctionReturnType = prevReturnType;
     return lines.join("\n");
   }
 
@@ -1849,6 +1860,7 @@ function generateFunction(f: SkittlesFunction): string {
     }
     lines.push("    }");
   }
+  cctx.currentFunctionReturnType = prevReturnType;
   return lines.join("\n");
 }
 
@@ -2084,13 +2096,43 @@ export function generateExpression(expr: Expression): string {
 // Statement generation
 // ============================================================
 
+/**
+ * Check whether an expression refers to an enum-typed state variable.
+ * Used to decide whether a uint256(...) cast is needed in return statements.
+ */
+function isEnumExpression(expr: Expression): boolean {
+  // Direct identifier: `status` (state variable)
+  if (expr.kind === "identifier") {
+    return cctx.currentEnumStateVarNames.has(expr.name);
+  }
+  // Property access: `this.status`
+  if (
+    expr.kind === "property-access" &&
+    expr.object.kind === "identifier" &&
+    expr.object.name === "this"
+  ) {
+    return cctx.currentEnumStateVarNames.has(expr.property);
+  }
+  return false;
+}
+
 export function generateStatement(stmt: Statement, indent: string): string {
   const inner = indent + "    ";
 
   switch (stmt.kind) {
     case "return":
       if (stmt.value) {
-        return `${indent}return ${generateExpression(stmt.value)};`;
+        let retExpr = generateExpression(stmt.value);
+        // When the function returns uint256 but the expression is an enum
+        // state variable, emit an explicit uint256(...) cast so Solidity
+        // doesn't reject the implicit enum→uint256 conversion.
+        if (
+          cctx.currentFunctionReturnType?.kind === SkittlesTypeKind.Uint256 &&
+          isEnumExpression(stmt.value)
+        ) {
+          retExpr = `uint256(${retExpr})`;
+        }
+        return `${indent}return ${retExpr};`;
       }
       return `${indent}return;`;
 

--- a/test/compiler/integration-types.test.ts
+++ b/test/compiler/integration-types.test.ts
@@ -375,6 +375,23 @@ describe("integration: enums", () => {
     );
   });
 
+  it("should emit uint256 cast when returning enum state variable from number-returning function", () => {
+    const { errors, solidity } = compileTS(`
+      enum VaultStatus { Active, Paused }
+
+      class Staking {
+        public status: VaultStatus = VaultStatus.Active;
+
+        public getStatus(): number {
+          return this.status;
+        }
+      }
+    `);
+    expect(errors).toHaveLength(0);
+    expect(solidity).toContain("returns (uint256)");
+    expect(solidity).toContain("return uint256(status);");
+  });
+
   it("should reject 'asserts' type predicates with a clear error", () => {
     expect(() =>
       compileTS(`


### PR DESCRIPTION
Closes #333

## Summary
When a function is declared to return `number` and returns an enum state variable directly, the generated Solidity fails to compile with:
```
TypeError: Return argument type enum X.MyEnum is not implicitly convertible to expected type (type of first return variable) uint256.
```

## Repro
``typescript
export enum VaultStatus {
  Active,
  Paused,
}

export class Staking {
  public status: VaultStatus = VaultStatus.Active;
  
  public getStatus(): number {
    return this.status;  // Fails: enum not cast to uint256
  }
}
```

## Workaround
Explicit if/else returning numeric literals:
``typescript
public getStatus(): number {
  if (this.status === VaultStatus.Active) return 0;
  return 1;
}
```

## Expected
The compiler should emit an explicit cast from the enum to uint256 when the return type is `number`, since TypeScript enums with numeric values are represented as numbers.
