### PR TITLE
Interface method balanceOf compiled as nonpayable instead of view; external calls return tx object

### DIFF
--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -10,6 +10,7 @@ import {
   type SkittlesType,
   type SkittlesContractInterface,
   type SkittlesInterfaceFunction,
+  type StateMutability,
   type Statement,
   type Expression,
   type NatSpec,
@@ -172,10 +173,26 @@ export function parseInterfaceAsContractInterface(
     ) {
       const methodName = member.name.text;
       const parameters = member.parameters.map(parseParameter);
-      const returnType: SkittlesType | null = member.type
-        ? parseType(member.type)
+
+      // Detect View<T> wrapper on return type to mark as view
+      let stateMutability: StateMutability | undefined;
+      let typeNode = member.type;
+      if (
+        typeNode &&
+        ts.isTypeReferenceNode(typeNode) &&
+        ts.isIdentifier(typeNode.typeName) &&
+        typeNode.typeName.text === "View" &&
+        typeNode.typeArguments &&
+        typeNode.typeArguments.length === 1
+      ) {
+        stateMutability = "view";
+        typeNode = typeNode.typeArguments[0];
+      }
+
+      const returnType: SkittlesType | null = typeNode
+        ? parseType(typeNode)
         : null;
-      functions.push({ name: methodName, parameters, returnType });
+      functions.push({ name: methodName, parameters, returnType, stateMutability });
     }
   }
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -47,6 +47,22 @@ export type SkittlesError<
  */
 export type Indexed<T> = T;
 
+/**
+ * Wrapper type to mark an interface method return type as `view`.
+ * View methods only read state and do not modify it. When called via
+ * ethers.js, view functions return the value directly instead of a
+ * transaction response.
+ *
+ * Usage:
+ * ```typescript
+ * interface IToken {
+ *   balanceOf(account: address): View<number>;
+ *   transfer(to: address, amount: number): boolean;
+ * }
+ * ```
+ */
+export type View<T> = T;
+
 // Compiler API (parser + codegen)
 export {
   parse,

--- a/test/compiler/integration-contracts.test.ts
+++ b/test/compiler/integration-contracts.test.ts
@@ -1154,6 +1154,101 @@ describe("integration: external contract calls", () => {
     const result = compileSolidity("Helper", solidity, defaultConfig);
     expect(result.errors).toHaveLength(0);
   });
+
+  it("should compile interface method with View<T> return type as view", () => {
+    const interfaceSrc = `
+      interface IToken {
+        balanceOf(account: address): View<number>;
+        transfer(to: address, amount: number): boolean;
+      }
+    `;
+    const { structs, enums, contractInterfaces } = collectTypes(
+      interfaceSrc,
+      "IToken.ts"
+    );
+    const externalTypes = { structs, enums, contractInterfaces };
+
+    // balanceOf should be view due to View<> wrapper
+    const balanceOfMethod = contractInterfaces
+      .get("IToken")!
+      .functions.find((f) => f.name === "balanceOf");
+    expect(balanceOfMethod?.stateMutability).toBe("view");
+
+    // transfer should remain unannotated (no View<> wrapper)
+    const transferMethod = contractInterfaces
+      .get("IToken")!
+      .functions.find((f) => f.name === "transfer");
+    expect(transferMethod?.stateMutability).toBeUndefined();
+
+    const contractSrc = `
+      class TokenVault {
+        private _token: IToken;
+
+        constructor(tokenAddress: address) {
+          this._token = Contract<IToken>(tokenAddress);
+        }
+
+        public getTokenBalance(account: address): number {
+          return this._token.balanceOf(account);
+        }
+      }
+    `;
+
+    const contracts = parse(contractSrc, "TokenVault.ts", externalTypes);
+    const solidity = generateSolidity(contracts[0]);
+
+    // balanceOf should be compiled as view in the interface
+    expect(solidity).toContain(
+      "function balanceOf(address account) external view returns (uint256);"
+    );
+    // transfer should remain without view
+    expect(solidity).toContain(
+      "function transfer(address to, uint256 amount) external returns (bool);"
+    );
+    // getTokenBalance should be view since it only calls a view method
+    expect(solidity).toMatch(/function getTokenBalance\(.*\) public view\b/);
+
+    const result = compileSolidity("TokenVault", solidity, defaultConfig);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should propagate View<T> mutability from interface to caller function", () => {
+    const interfaceSrc = `
+      interface IToken {
+        balanceOf(account: address): View<number>;
+      }
+    `;
+    const { structs, enums, contractInterfaces } = collectTypes(
+      interfaceSrc,
+      "IToken.ts"
+    );
+    const externalTypes = { structs, enums, contractInterfaces };
+
+    const contractSrc = `
+      class Checker {
+        public checkBalance(tokenAddress: address, account: address): number {
+          let token: IToken = Contract<IToken>(tokenAddress);
+          return token.balanceOf(account);
+        }
+      }
+    `;
+
+    const contracts = parse(contractSrc, "Checker.ts", externalTypes);
+    const checkBalanceFn = contracts[0].functions.find(
+      (f) => f.name === "checkBalance"
+    );
+    expect(checkBalanceFn).toBeDefined();
+    // balanceOf is annotated as view via View<>, so checkBalance should be view
+    expect(checkBalanceFn!.stateMutability).toBe("view");
+
+    const solidity = generateSolidity(contracts[0]);
+    expect(solidity).toContain(
+      "function balanceOf(address account) external view returns (uint256);"
+    );
+
+    const result = compileSolidity("Checker", solidity, defaultConfig);
+    expect(result.errors).toHaveLength(0);
+  });
 });
 
 describe("integration: ETH transfers", () => {


### PR DESCRIPTION
Closes #335

When a contract uses Contract<IToken>(addr) and calls this._token.balanceOf(account), the IToken interface compiles balanceOf as `external returns (uint256)` (nonpayable) instead of `external view returns (uint256)`.

As a result:
- TokenVault.getTokenBalance() is compiled without the view modifier
- When called from ethers.js, the call returns a ContractTransactionResponse object instead of the uint256 return value
- Workaround: use `vault.getTokenBalance.staticCall(addr)` to force a static call and get the return value

Expectation: Interface methods that only read state (like balanceOf) should be compiled with the view modifier so that direct calls return the value.

Repro: Use Contract<IToken> with interface `balanceOf(account: address): number`, call from a wrapper, then call wrapper from ethers without staticCall.