### PR TITLE
Align debounce values between compile watch and Playground [XXS]

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -5,7 +5,8 @@ import { loadConfig } from "../config/config.ts";
 import { compile } from "../compiler/compiler.ts";
 import { logSuccess, logError, logInfo } from "../utils/console.ts";
 
-const DEBOUNCE_MS = 200;
+// Debounce delay for file-watch recompilation (aligned with webapp/src/Playground.tsx)
+const DEBOUNCE_MS = 300;
 
 async function executeCompilation(
   projectRoot: string,

--- a/webapp/src/Playground.tsx
+++ b/webapp/src/Playground.tsx
@@ -96,6 +96,7 @@ export class Staking {
 };
 
 const DEFAULT_EXAMPLE = "Token";
+// Debounce delay for recompile-on-change (aligned with src/commands/compile.ts)
 const DEBOUNCE_MS = 300;
 
 function encodeSource(source: string): string {


### PR DESCRIPTION
Closes #349

## Problem
- `src/commands/compile.ts`: DEBOUNCE_MS = 200
- `webapp/src/Playground.tsx`: DEBOUNCE_MS = 300

Different debounce delays for similar "recompile on change" behavior. No clear reason for the difference.

## Solution
Use a single constant or document the rationale. If Playground needs longer debounce for UX (fewer recompiles while typing), add a comment. Consider extracting to a shared constant if both are in the same package, or document the difference.