### PR TITLE
Extract duplicate array destructuring error message to constant [XXS]

### DIFF
--- a/src/compiler/statement-parser.ts
+++ b/src/compiler/statement-parser.ts
@@ -29,6 +29,10 @@ const UNSUPPORTED_OBJECT_DESTRUCTURING_MSG =
   "Only simple bindings are allowed, e.g. `{ a }` or `{ prop: name }` " +
   "with no default values, rest elements, computed property names, or nested patterns.";
 
+const UNSUPPORTED_ARRAY_DESTRUCTURING_BINDING_MSG =
+  "Unsupported array destructuring binding element in variable declaration. " +
+  "Only simple identifier bindings are allowed (no default values, rest elements, renames, or nested patterns).";
+
 function validateArrayLiteralElements(
   elements: ts.NodeArray<ts.Expression>
 ): void {
@@ -71,10 +75,7 @@ export function parseArrayDestructuring(
         !!elem.dotDotDotToken ||
         !!elem.propertyName
       ) {
-        throw new Error(
-          "Unsupported array destructuring binding element in variable declaration. " +
-            "Only simple identifier bindings are allowed (no default values, rest elements, renames, or nested patterns)."
-        );
+        throw new Error(UNSUPPORTED_ARRAY_DESTRUCTURING_BINDING_MSG);
       }
       const name = elem.name.text;
       validateReservedVarName(name);
@@ -135,10 +136,7 @@ export function parseArrayDestructuring(
         !!elem.dotDotDotToken ||
         !!elem.propertyName
       ) {
-        throw new Error(
-          "Unsupported array destructuring binding element in variable declaration. " +
-            "Only simple identifier bindings are allowed (no default values, rest elements, renames, or nested patterns)."
-        );
+        throw new Error(UNSUPPORTED_ARRAY_DESTRUCTURING_BINDING_MSG);
       }
       const name = elem.name.text;
       validateReservedVarName(name);


### PR DESCRIPTION
Closes #344

## Problem
In `src/compiler/statement-parser.ts`, the exact same error message appears twice (lines 75 and 139):
`"Unsupported array destructuring binding element in variable declaration. " +
"Only simple identifier bindings are allowed (no default values, rest elements, renames, or nested patterns)."`

## Solution
Extract to a constant `UNSUPPORTED_ARRAY_DESTRUCTURING_BINDING_MSG` at the top of the file (similar to `UNSUPPORTED_OBJECT_DESTRUCTURING_MSG` on line 27).