### PR TITLE
Unify ZERO_ADDRESS constant format [XXS]

### DIFF
--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,4 +1,4 @@
-export const ZERO_ADDRESS = "0x" + "0".repeat(40);
+export { ZERO_ADDRESS } from "../stdlib/contracts/constants.ts";
 export const MAX_UINT256 = (1n << 256n) - 1n;
 export const INITIAL_SUPPLY = 1_000_000n;
 export const BEHAVIORAL_TIMEOUT = 30_000;


### PR DESCRIPTION
Closes #348

## Problem
- `test/constants.ts`: `ZERO_ADDRESS = "0x" + "0".repeat(40)`
- `stdlib/contracts/constants.ts`: `ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"`

Same semantic value, different representations. Tests and stdlib could drift.

## Solution
Define ZERO_ADDRESS once (e.g. in a shared constants module or stdlib) and import in test/constants.ts. Or document that both are valid and add a test that they are equal.