### PR TITLE
Consolidate URL constants between webapp and docs [S]

### DIFF
--- a/constants/urls.ts
+++ b/constants/urls.ts
@@ -1,0 +1,12 @@
+export const URLS = {
+  website: "https://skittles.dev",
+  docs: "https://docs.skittles.dev",
+  github: "https://github.com/chase-manning/skittles",
+  githubExamples: "https://github.com/chase-manning/skittles/tree/main/example",
+  githubReleases: "https://github.com/chase-manning/skittles/releases",
+  githubIssues: "https://github.com/chase-manning/skittles/issues",
+  githubLicense:
+    "https://github.com/chase-manning/skittles/blob/main/LICENSE",
+  npm: "https://www.npmjs.com/package/skittles",
+  npmApi: "https://registry.npmjs.org/skittles/latest",
+};

--- a/docs/constants.ts
+++ b/docs/constants.ts
@@ -1,5 +1,1 @@
-export const URLS = {
-  website: "https://skittles.dev",
-  github: "https://github.com/chase-manning/skittles",
-  npm: "https://www.npmjs.com/package/skittles",
-};
+export { URLS } from "../constants/urls";

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,11 +1,1 @@
-export const URLS = {
-  docs: "https://docs.skittles.dev",
-  github: "https://github.com/chase-manning/skittles",
-  githubExamples: "https://github.com/chase-manning/skittles/tree/main/example",
-  githubReleases: "https://github.com/chase-manning/skittles/releases",
-  githubIssues: "https://github.com/chase-manning/skittles/issues",
-  githubLicense:
-    "https://github.com/chase-manning/skittles/blob/main/LICENSE",
-  npm: "https://www.npmjs.com/package/skittles",
-  npmApi: "https://registry.npmjs.org/skittles/latest",
-};
+export { URLS } from "../../constants/urls.ts";

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   server: {
     fs: {
-      allow: ['.', '../src'],
+      allow: ['.', '../src', '../constants'],
     },
   },
   build: {


### PR DESCRIPTION
Closes #342

## Problem
- `webapp/src/constants.ts` has: docs, github, githubExamples, githubReleases, githubIssues, githubLicense, npm, npmApi
- `docs/constants.ts` has: website, github, npm

Different URL sets, potential for drift. Docs has `website`, webapp has `docs`; both have github and npm.

## Solution
Create a shared `packages/constants` or root `constants/urls.ts` that both can import, or document the split and ensure cross-links use the same base URLs. Consider a single source of truth for all Skittles-related URLs.