### PR TITLE
Extract init command CONFIG_TEMPLATE from DEFAULT_CONFIG [S]

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,13 +3,14 @@ import fs from "fs";
 import { execSync } from "child_process";
 import { writeFile, ensureDirectory } from "../utils/file.ts";
 import { logSuccess, logError, logInfo, logWarning } from "../utils/console.ts";
+import { DEFAULT_CONFIG } from "../config/defaults.ts";
 
 const CONFIG_TEMPLATE = JSON.stringify(
   {
-    typeCheck: true,
+    typeCheck: DEFAULT_CONFIG.typeCheck,
     consoleLog: true,
-    contractsDir: "contracts",
-    outputDir: "artifacts",
+    contractsDir: DEFAULT_CONFIG.contractsDir,
+    outputDir: DEFAULT_CONFIG.outputDir,
   },
   null,
   2


### PR DESCRIPTION
Closes #360

## Problem
`src/commands/init.ts` defines CONFIG_TEMPLATE with a subset of config:
```ts
const CONFIG_TEMPLATE = JSON.stringify({
  typeCheck: true,
  consoleLog: true,
  contractsDir: "contracts",
  outputDir: "artifacts",
}, null, 2);
```

This overlaps with DEFAULT_CONFIG in config/defaults.ts. If defaults change, init may write outdated config.

## Solution
Build CONFIG_TEMPLATE from DEFAULT_CONFIG (or a merge of it with init-specific overrides like consoleLog: true). Ensures init template stays in sync with actual defaults.