### PR TITLE
Extract enum member name helper to reduce 'Unknown' fallback duplication [XXS]

### DIFF
--- a/src/compiler/class-parser.ts
+++ b/src/compiler/class-parser.ts
@@ -23,6 +23,7 @@ import {
   validateReservedVarName,
   getVisibility,
   hasModifier,
+  getNodeName,
 } from "./parser-utils.ts";
 import { parseType, inferType, parseTypeLiteralFields } from "./type-parser.ts";
 import { parseExpression } from "./expression-parser.ts";
@@ -213,7 +214,7 @@ export function parseClass(
   fileFunctions: SkittlesFunction[] = [],
   fileConstants: Map<string, Expression> = new Map()
 ): SkittlesContract {
-  const name = node.name?.text ?? "Unknown";
+  const name = getNodeName(node);
   const isAbstract = hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword);
   const variables: SkittlesVariable[] = [];
   const functions: SkittlesFunction[] = [];
@@ -766,8 +767,7 @@ export function tryParseEvent(
     : "";
   if (typeName !== "SkittlesEvent" && typeName !== "Event") return null;
 
-  const name =
-    node.name && ts.isIdentifier(node.name) ? node.name.text : "Unknown";
+  const name = getNodeName(node);
 
   const natspec = parseNatSpec(node);
 
@@ -827,8 +827,7 @@ export function tryParseError(
     : "";
   if (typeName !== "SkittlesError") return null;
 
-  const name =
-    node.name && ts.isIdentifier(node.name) ? node.name.text : "Unknown";
+  const name = getNodeName(node);
 
   if (!node.type.typeArguments || node.type.typeArguments.length === 0) {
     return { name, parameters: [] };

--- a/src/compiler/expression-parser.ts
+++ b/src/compiler/expression-parser.ts
@@ -45,6 +45,7 @@ import {
   collectBareIdentifiers,
   collectBareIdentifiersFromStmts,
   validateCallbackScope,
+  getNodeName,
 } from "./parser-utils.ts";
 import { parseType, inferType } from "./type-parser.ts";
 import { inferStateMutability } from "./mutability.ts";
@@ -874,9 +875,7 @@ export function parseExpression(node: ts.Expression): Expression {
   }
 
   if (ts.isNewExpression(node)) {
-    const callee = ts.isIdentifier(node.expression)
-      ? node.expression.text
-      : "Unknown";
+    const callee = getNodeName(node.expression);
     const args = node.arguments
       ? Array.from(node.arguments).map(parseExpression)
       : [];

--- a/src/compiler/parser-utils.ts
+++ b/src/compiler/parser-utils.ts
@@ -10,6 +10,20 @@ import {
 } from "../types/index.ts";
 import { ctx } from "./parser-context.ts";
 
+export function getEnumMemberName(member: ts.EnumMember): string {
+  return ts.isIdentifier(member.name) ? member.name.text : "Unknown";
+}
+
+export function getNodeName(node: ts.Node): string {
+  if (ts.isIdentifier(node)) return node.text;
+  const named = node as ts.NamedDeclaration;
+  if (named.name) {
+    if (ts.isIdentifier(named.name)) return named.name.text;
+    if ("text" in named.name) return (named.name as unknown as ts.Identifier).text;
+  }
+  return "Unknown";
+}
+
 export function getSourceLine(node: ts.Node): number | undefined {
   if (!ctx.currentSourceFile) return undefined;
   return (

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -26,6 +26,7 @@ import {
   parseInterfaceAsContractInterface,
   parseClass,
 } from "./class-parser.ts";
+import { getEnumMemberName } from "./parser-utils.ts";
 
 // Re-export public API from sub-modules
 export type { ParserContext } from "./parser-context.ts";
@@ -53,9 +54,7 @@ function collectStructsAndEnums(
       structs.set(node.name.text, parseTypeLiteralFields(node.type));
     }
     if (ts.isEnumDeclaration(node) && node.name) {
-      const members = node.members.map((m) =>
-        ts.isIdentifier(m.name) ? m.name.text : "Unknown"
-      );
+      const members = node.members.map((m) => getEnumMemberName(m));
       enums.set(node.name.text, members);
     }
   });

--- a/test/compiler/parser-utils.test.ts
+++ b/test/compiler/parser-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { getEnumMemberName, getNodeName } from "../../src/compiler/parser-utils";
+import ts from "typescript";
+
+function makeEnumMember(code: string): ts.EnumMember {
+  const src = ts.createSourceFile(
+    "t.ts",
+    `enum E { ${code} }`,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const decl = src.statements[0] as ts.EnumDeclaration;
+  return decl.members[0];
+}
+
+function makeNode(code: string): ts.Node {
+  const src = ts.createSourceFile(
+    "t.ts",
+    code,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  return src.statements[0];
+}
+
+describe("getEnumMemberName", () => {
+  it("returns the name of an identifier enum member", () => {
+    const member = makeEnumMember("Foo");
+    expect(getEnumMemberName(member)).toBe("Foo");
+  });
+
+  it("returns 'Unknown' for a computed enum member", () => {
+    const member = makeEnumMember('"computed-key" = 1');
+    expect(getEnumMemberName(member)).toBe("Unknown");
+  });
+});
+
+describe("getNodeName", () => {
+  it("returns the name of a class declaration", () => {
+    const node = makeNode("class MyClass {}");
+    expect(getNodeName(node)).toBe("MyClass");
+  });
+
+  it("returns the name of an enum declaration", () => {
+    const node = makeNode("enum MyEnum { A, B }");
+    expect(getNodeName(node)).toBe("MyEnum");
+  });
+
+  it("returns the text of an identifier node", () => {
+    const src = ts.createSourceFile(
+      "t.ts",
+      "foo;",
+      ts.ScriptTarget.Latest,
+      true
+    );
+    const stmt = src.statements[0] as ts.ExpressionStatement;
+    expect(getNodeName(stmt.expression)).toBe("foo");
+  });
+
+  it("returns 'Unknown' for a node without a name", () => {
+    const node = makeNode("1 + 2;");
+    expect(getNodeName(node)).toBe("Unknown");
+  });
+});


### PR DESCRIPTION
Closes #343

## Problem
The pattern `ts.isIdentifier(m.name) ? m.name.text : "Unknown"` appears in:
- src/compiler/parser.ts (lines 85, 186, 462)
- src/compiler/class-parser.ts (lines 770, 831)
- src/compiler/expression-parser.ts (line 879)

And `node.name?.text ?? "Unknown"` in class-parser.ts line 216.

## Solution
Add `getEnumMemberName(member: ts.EnumMember): string` and `getNodeName(node: ts.Node): string` helpers in parser-utils.ts and use consistently.