### PR TITLE
Extract CACHE_HASH_LENGTH constant for hashString slice [XXS]

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -52,7 +52,7 @@ export interface CompilationResult {
 // Incremental compilation cache
 // ============================================================
 
-import { CACHE_VERSION } from "./constants.ts";
+import { CACHE_HASH_LENGTH, CACHE_VERSION } from "./constants.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_VERSION: string = JSON.parse(
@@ -80,7 +80,7 @@ interface CompilationCache {
 }
 
 function hashString(input: string): string {
-  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
+  return crypto.createHash("sha256").update(input).digest("hex").slice(0, CACHE_HASH_LENGTH);
 }
 
 function baseName(filePath: string): string {

--- a/src/compiler/constants.ts
+++ b/src/compiler/constants.ts
@@ -39,3 +39,10 @@ export const BATCH_SOURCE_FILENAME = "Contracts.sol";
  *   "5" – current format.
  */
 export const CACHE_VERSION = "5";
+
+/**
+ * Number of hex characters to keep from the SHA-256 digest when hashing
+ * cache keys.  16 hex chars = 64 bits – enough to avoid collisions in
+ * practice while keeping keys short.
+ */
+export const CACHE_HASH_LENGTH = 16;


### PR DESCRIPTION
Closes #353

## Problem
In `src/compiler/compiler.ts`, `hashString` uses `.slice(0, 16)` as a magic number:
```ts
function hashString(input: string): string {
  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
}
```

## Solution
Add `CACHE_HASH_LENGTH = 16` to `src/compiler/constants.ts` (alongside CACHE_VERSION) and use it. Documents intent and allows tuning if needed.