### PR TITLE
Unify test defaultConfig with config defaults [S]

### DIFF
--- a/test/compiler/cache.test.ts
+++ b/test/compiler/cache.test.ts
@@ -3,18 +3,12 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { compile } from "../../src/compiler/compiler";
-import type { SkittlesConfig } from "../../src/types";
 import * as parserModule from "../../src/compiler/parser";
-import { defaultConfig as baseDefaultConfig } from "../fixtures.js";
+import { defaultConfig } from "../fixtures.js";
 
 const pkgJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8")
 );
-
-const defaultConfig: Required<SkittlesConfig> = {
-  ...baseDefaultConfig,
-  solidity: { version: "^0.8.20", license: "MIT" },
-};
 
 function createTempProject(): string {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "skittles-cache-test-"));

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,22 +1,9 @@
 import { beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
-import type { SkittlesConfig } from "../src/types";
+import { DEFAULT_CONFIG } from "../src/config/defaults";
 
-export const defaultConfig: Required<SkittlesConfig> = {
-  typeCheck: true,
-  optimizer: { enabled: false, runs: 200 },
-  contractsDir: "contracts",
-  outputDir: "artifacts",
-  cacheDir: "cache",
-  consoleLog: false,
-  formatting: {
-    indent: 4,
-    bracketSpacing: true,
-    braceStyle: "same-line" as const,
-    formatOutput: false,
-  },
-};
+export const defaultConfig = DEFAULT_CONFIG;
 
 /**
  * Register beforeEach/afterEach hooks that create and clean up a temporary


### PR DESCRIPTION
Closes #347

## Problem
`test/fixtures.ts` defines `defaultConfig` that duplicates `src/config/defaults.ts` DEFAULT_CONFIG. The test config has `optimizer: { enabled: false, runs: 200 }` and other fields. Any change to defaults requires updating both.

## Solution
Import `DEFAULT_CONFIG` from config in fixtures.ts and re-export or use directly. If tests need overrides, use `{ ...DEFAULT_CONFIG, contractsDir: 'custom' }` instead of redefining the full object.