### PR TITLE
Replace empty catch blocks with explicit comment or logging [XXS]

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -95,7 +95,7 @@ function loadCache(outputDir: string): CompilationCache {
       )
         return data;
     }
-  } catch {
+  } catch (_ignored) {
     // Corrupt cache, start fresh
   }
   return {
@@ -873,7 +873,7 @@ function generateOutput(
 function updateCache(cacheDir: string, newCache: CompilationCache): void {
   try {
     saveCache(cacheDir, newCache);
-  } catch {
+  } catch (_ignored) {
     // Non critical if cache save fails
   }
 }

--- a/webapp/src/Playground.tsx
+++ b/webapp/src/Playground.tsx
@@ -15,7 +15,8 @@ function encodeSource(source: string): string {
 function decodeSource(encoded: string): string | null {
   try {
     return decodeURIComponent(atob(encoded));
-  } catch {
+  } catch (_ignored) {
+    /* Invalid base64 or URI encoding, return null */
     return null;
   }
 }
@@ -114,7 +115,8 @@ export default function Playground() {
       await navigator.clipboard.writeText(url);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
+    } catch (_ignored) {
+      /* Clipboard API not available, fall back to prompt */
       window.prompt("Copy this URL to share:", url);
     }
   };


### PR DESCRIPTION
Closes #358

## Problem
Several catch blocks silently swallow errors:
- `src/compiler/compiler.ts` loadCache: `catch { } ` (corrupt cache, start fresh)
- `src/compiler/compiler.ts` updateCache: `catch { } ` (non critical if cache save fails)
- `webapp/src/Playground.tsx` decodeSource: `catch { return null }`

These are intentional but could be clearer. Empty catch is a code smell.

## Solution
Add explicit comments: `catch { /* Corrupt cache, start fresh */ }` or use a named variable `catch (_ignored) { /* ... */ }`. For updateCache, consider logging at debug level if cache save fails. Improves maintainability.