### PR TITLE
Share statement tree walking for console.log detection and stripping [M]

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -29,6 +29,7 @@ import {
   ERR_START_OUT_OF_BOUNDS,
 } from "./constants.ts";
 import { cctx } from "./codegen-context.ts";
+import { walkStatements } from "./walker.ts";
 export type { CodegenContext } from "./codegen-context.ts";
 export { resetCodegenContext } from "./codegen-context.ts";
 
@@ -2542,30 +2543,13 @@ function tryGenerateBuiltinCall(expr: {
 // ============================================================
 
 function statementsUseConsoleLog(stmts: Statement[]): boolean {
-  for (const stmt of stmts) {
-    if (stmt.kind === "console-log") return true;
-    if (stmt.kind === "if") {
-      if (statementsUseConsoleLog(stmt.thenBody)) return true;
-      if (stmt.elseBody && statementsUseConsoleLog(stmt.elseBody)) return true;
-    }
-    if (
-      stmt.kind === "for" ||
-      stmt.kind === "while" ||
-      stmt.kind === "do-while"
-    ) {
-      if (statementsUseConsoleLog(stmt.body)) return true;
-    }
-    if (stmt.kind === "switch") {
-      for (const c of stmt.cases) {
-        if (statementsUseConsoleLog(c.body)) return true;
-      }
-    }
-    if (stmt.kind === "try-catch") {
-      if (statementsUseConsoleLog(stmt.successBody)) return true;
-      if (statementsUseConsoleLog(stmt.catchBody)) return true;
-    }
-  }
-  return false;
+  let found = false;
+  walkStatements(stmts, {
+    visitStatement(stmt) {
+      if (stmt.kind === "console-log") found = true;
+    },
+  });
+  return found;
 }
 
 function contractUsesConsoleLog(contract: SkittlesContract): boolean {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -32,7 +32,7 @@ import {
 import { formatSolidity } from "./formatter.ts";
 import { analyzeFunction } from "./analysis.ts";
 import { MUTABILITY_RANK } from "./mutability.ts";
-import { walkStatements } from "./walker.ts";
+import { walkStatements, filterStatements } from "./walker.ts";
 import {
   getStdlibClassNames,
   resolveStdlibFiles,
@@ -1024,42 +1024,9 @@ function collectThisCallNames(stmts: Statement[]): {
 
 /**
  * Recursively remove console-log statements from an IR statement list.
+ * Uses the shared filterStatements walker from walker.ts.
  * Used when the consoleLog config option is disabled (production builds).
  */
 function stripConsoleLogStatements(stmts: Statement[]): Statement[] {
-  return stmts.reduce<Statement[]>((acc, stmt) => {
-    if (stmt.kind === "console-log") return acc;
-    if (stmt.kind === "if") {
-      acc.push({
-        ...stmt,
-        thenBody: stripConsoleLogStatements(stmt.thenBody),
-        elseBody: stmt.elseBody
-          ? stripConsoleLogStatements(stmt.elseBody)
-          : undefined,
-      });
-    } else if (
-      stmt.kind === "for" ||
-      stmt.kind === "while" ||
-      stmt.kind === "do-while"
-    ) {
-      acc.push({ ...stmt, body: stripConsoleLogStatements(stmt.body) });
-    } else if (stmt.kind === "switch") {
-      acc.push({
-        ...stmt,
-        cases: stmt.cases.map((c) => ({
-          ...c,
-          body: stripConsoleLogStatements(c.body),
-        })),
-      });
-    } else if (stmt.kind === "try-catch") {
-      acc.push({
-        ...stmt,
-        successBody: stripConsoleLogStatements(stmt.successBody),
-        catchBody: stripConsoleLogStatements(stmt.catchBody),
-      });
-    } else {
-      acc.push(stmt);
-    }
-    return acc;
-  }, []);
+  return filterStatements(stmts, (stmt) => stmt.kind === "console-log");
 }

--- a/src/compiler/walker.ts
+++ b/src/compiler/walker.ts
@@ -128,3 +128,53 @@ export function walkStatements(
 
   stmts.forEach(walkStmt);
 }
+
+/**
+ * Recursively filter a statement list, removing any statements for which the
+ * predicate returns `true`. The predicate is tested against statements nested
+ * inside control-flow structures (if/for/while/do-while/switch/try-catch) so
+ * that matching nodes deep in the tree are also removed.
+ */
+export function filterStatements(
+  stmts: Statement[],
+  shouldRemove: (stmt: Statement) => boolean
+): Statement[] {
+  return stmts.reduce<Statement[]>((acc, stmt) => {
+    if (shouldRemove(stmt)) return acc;
+    if (stmt.kind === "if") {
+      acc.push({
+        ...stmt,
+        thenBody: filterStatements(stmt.thenBody, shouldRemove),
+        elseBody: stmt.elseBody
+          ? filterStatements(stmt.elseBody, shouldRemove)
+          : undefined,
+      });
+    } else if (
+      stmt.kind === "for" ||
+      stmt.kind === "while" ||
+      stmt.kind === "do-while"
+    ) {
+      acc.push({
+        ...stmt,
+        body: filterStatements(stmt.body, shouldRemove),
+      });
+    } else if (stmt.kind === "switch") {
+      acc.push({
+        ...stmt,
+        cases: stmt.cases.map((c) => ({
+          ...c,
+          body: filterStatements(c.body, shouldRemove),
+        })),
+      });
+    } else if (stmt.kind === "try-catch") {
+      acc.push({
+        ...stmt,
+        successBody: filterStatements(stmt.successBody, shouldRemove),
+        catchBody: filterStatements(stmt.catchBody, shouldRemove),
+      });
+    } else {
+      acc.push(stmt);
+    }
+    return acc;
+  }, []);
+}

--- a/test/compiler/walker.test.ts
+++ b/test/compiler/walker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { walkStatements, walkExpression } from "../../src/compiler/walker";
+import { walkStatements, walkExpression, filterStatements } from "../../src/compiler/walker";
 import type { ASTVisitor } from "../../src/compiler/walker";
 import type { Statement, Expression } from "../../src/types/index";
 
@@ -376,5 +376,136 @@ describe("walkStatements", () => {
       },
     });
     expect(identifiers).toEqual(new Set(["a", "b", "flag", "x"]));
+  });
+});
+
+// ============================================================
+// filterStatements
+// ============================================================
+
+describe("filterStatements", () => {
+  it("should remove top-level statements matching the predicate", () => {
+    const stmts: Statement[] = [
+      { kind: "console-log", args: [{ kind: "string-literal", value: "hi" }] },
+      { kind: "break" },
+      { kind: "console-log", args: [] },
+      { kind: "continue" },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    expect(result.map((s) => s.kind)).toEqual(["break", "continue"]);
+  });
+
+  it("should remove statements nested inside if/else bodies", () => {
+    const stmts: Statement[] = [
+      {
+        kind: "if",
+        condition: { kind: "boolean-literal", value: true },
+        thenBody: [
+          { kind: "console-log", args: [] },
+          { kind: "break" },
+        ],
+        elseBody: [
+          { kind: "continue" },
+          { kind: "console-log", args: [] },
+        ],
+      },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    expect(result.length).toBe(1);
+    const ifStmt = result[0];
+    if (ifStmt.kind !== "if") throw new Error("expected if");
+    expect(ifStmt.thenBody.map((s) => s.kind)).toEqual(["break"]);
+    expect(ifStmt.elseBody?.map((s) => s.kind)).toEqual(["continue"]);
+  });
+
+  it("should remove statements nested inside for/while/do-while bodies", () => {
+    const stmts: Statement[] = [
+      {
+        kind: "for",
+        initializer: undefined,
+        condition: undefined,
+        incrementor: undefined,
+        body: [
+          { kind: "console-log", args: [] },
+          { kind: "break" },
+        ],
+      },
+      {
+        kind: "while",
+        condition: { kind: "boolean-literal", value: true },
+        body: [
+          { kind: "console-log", args: [] },
+          { kind: "continue" },
+        ],
+      },
+      {
+        kind: "do-while",
+        condition: { kind: "boolean-literal", value: false },
+        body: [
+          { kind: "console-log", args: [] },
+          { kind: "break" },
+        ],
+      },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    expect(result.length).toBe(3);
+    for (const stmt of result) {
+      if (stmt.kind === "for" || stmt.kind === "while" || stmt.kind === "do-while") {
+        expect(stmt.body.every((s) => s.kind !== "console-log")).toBe(true);
+        expect(stmt.body.length).toBe(1);
+      }
+    }
+  });
+
+  it("should remove statements nested inside switch cases", () => {
+    const stmts: Statement[] = [
+      {
+        kind: "switch",
+        discriminant: { kind: "identifier", name: "x" },
+        cases: [
+          {
+            value: { kind: "number-literal", value: "1" },
+            body: [
+              { kind: "console-log", args: [] },
+              { kind: "break" },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    if (result[0].kind !== "switch") throw new Error("expected switch");
+    expect(result[0].cases[0].body.map((s) => s.kind)).toEqual(["break"]);
+  });
+
+  it("should remove statements nested inside try-catch bodies", () => {
+    const stmts: Statement[] = [
+      {
+        kind: "try-catch",
+        call: { kind: "call", callee: { kind: "identifier", name: "foo" }, args: [] },
+        successBody: [
+          { kind: "console-log", args: [] },
+          { kind: "break" },
+        ],
+        catchBody: [
+          { kind: "console-log", args: [] },
+          { kind: "continue" },
+        ],
+        catchParamName: "e",
+      },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    if (result[0].kind !== "try-catch") throw new Error("expected try-catch");
+    expect(result[0].successBody.map((s) => s.kind)).toEqual(["break"]);
+    expect(result[0].catchBody.map((s) => s.kind)).toEqual(["continue"]);
+  });
+
+  it("should return all statements when none match the predicate", () => {
+    const stmts: Statement[] = [
+      { kind: "break" },
+      { kind: "continue" },
+    ];
+    const result = filterStatements(stmts, (s) => s.kind === "console-log");
+    expect(result.map((s) => s.kind)).toEqual(["break", "continue"]);
   });
 });


### PR DESCRIPTION
Closes #352

## Problem
In `src/compiler/compiler.ts` and `codegen.ts`:
- `stripConsoleLogStatements(stmts)` recursively walks if/for/while/switch/try-catch and removes console-log nodes
- `statementsUseConsoleLog(stmts)` and `contractUsesConsoleLog(contract)` in codegen.ts do similar recursive walking to detect console.log

Both traverse the same statement tree structure. The walker.ts `walkStatements` could be extended or a shared "visit statements with callback" could reduce duplication.

## Solution
Use `walkStatements` from walker.ts with a visitor that either (a) filters out console-log, or (b) detects presence of console-log. Implement stripConsoleLogStatements and statementsUseConsoleLog using the shared walker instead of custom reduce/map logic.