### PR TITLE
Use DEFAULT_CONFIG in test fixtures instead of duplicating [XS]

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach } from "vitest";
 
 import { DEFAULT_CONFIG } from "../src/config/defaults";
 
-export const defaultConfig = DEFAULT_CONFIG;
+export const defaultConfig = { ...DEFAULT_CONFIG, consoleLog: false };
 
 /**
  * Register beforeEach/afterEach hooks that create and clean up a temporary


### PR DESCRIPTION
Closes #391

## Problem
`test/fixtures.ts` defines `defaultConfig` that duplicates the structure of `DEFAULT_CONFIG` from `src/config/defaults.ts`. The test config has `consoleLog: false` (intentional for tests) but the rest could be derived.

## Solution
Import DEFAULT_CONFIG and spread/override only what tests need:
```ts
import { DEFAULT_CONFIG } from "../src/config/defaults";
export const defaultConfig = { ...DEFAULT_CONFIG, consoleLog: false };
```
This ensures test defaults stay in sync with production defaults when new config keys are added.