### PR TITLE
Extract TypeScript file filter logic to shared utility [XS]

### DIFF
--- a/src/stdlib/resolver.ts
+++ b/src/stdlib/resolver.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
+import { isTypeScriptSourceFile } from "../utils/file.ts";
 import { findExtendsReferences } from "../utils/regex.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -26,11 +27,7 @@ function buildRegistry(): StdlibEntry[] {
     for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
       if (item.isDirectory()) {
         walk(path.join(dir, item.name));
-      } else if (
-        item.name.endsWith(".ts") &&
-        !item.name.endsWith(".d.ts") &&
-        item.name !== "index.ts"
-      ) {
+      } else if (isTypeScriptSourceFile(item.name, { excludeIndex: true })) {
         const className = item.name.replace(/\.ts$/, "");
         entries.push({
           className,

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -2,6 +2,20 @@ import fs from "fs";
 import path from "path";
 
 /**
+ * Check if a filename is a TypeScript source file (.ts but not .d.ts).
+ * Optionally exclude index.ts files.
+ */
+export function isTypeScriptSourceFile(
+  name: string,
+  options?: { excludeIndex?: boolean }
+): boolean {
+  if (!name.endsWith(".ts")) return false;
+  if (name.endsWith(".d.ts")) return false;
+  if (options?.excludeIndex && name === "index.ts") return false;
+  return true;
+}
+
+/**
  * Recursively find all TypeScript files in a directory
  */
 export function findTypeScriptFiles(dir: string): string[] {
@@ -17,7 +31,7 @@ export function findTypeScriptFiles(dir: string): string[] {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...findTypeScriptFiles(fullPath));
-    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+    } else if (isTypeScriptSourceFile(entry.name)) {
       files.push(fullPath);
     }
   }

--- a/test/utils/file.test.ts
+++ b/test/utils/file.test.ts
@@ -5,6 +5,7 @@ import { describe, expect,it } from "vitest";
 import {
   ensureDirectory,
   findTypeScriptFiles,
+  isTypeScriptSourceFile,
   readFile,
   removeDirectory,
   writeFile,
@@ -12,6 +13,35 @@ import {
 import { useTempDir } from "../fixtures";
 
 const TEST_DIR = useTempDir(__dirname);
+
+describe("isTypeScriptSourceFile", () => {
+  it("should return true for .ts files", () => {
+    expect(isTypeScriptSourceFile("foo.ts")).toBe(true);
+  });
+
+  it("should return false for .d.ts files", () => {
+    expect(isTypeScriptSourceFile("foo.d.ts")).toBe(false);
+  });
+
+  it("should return false for non-ts files", () => {
+    expect(isTypeScriptSourceFile("foo.js")).toBe(false);
+    expect(isTypeScriptSourceFile("foo.txt")).toBe(false);
+  });
+
+  it("should not exclude index.ts by default", () => {
+    expect(isTypeScriptSourceFile("index.ts")).toBe(true);
+  });
+
+  it("should exclude index.ts when excludeIndex is true", () => {
+    expect(isTypeScriptSourceFile("index.ts", { excludeIndex: true })).toBe(
+      false
+    );
+  });
+
+  it("should not exclude non-index files when excludeIndex is true", () => {
+    expect(isTypeScriptSourceFile("foo.ts", { excludeIndex: true })).toBe(true);
+  });
+});
 
 describe("findTypeScriptFiles", () => {
   it("should find .ts files in a directory", () => {


### PR DESCRIPTION
Closes #395

## Problem
- `src/utils/file.ts` `findTypeScriptFiles`: filters `.ts` and excludes `.d.ts`
- `src/stdlib/resolver.ts` `buildRegistry`: filters `.ts`, excludes `.d.ts` and `index.ts`

The "is this a TypeScript source file" logic is duplicated with slight variations. The resolver also excludes index.ts which findTypeScriptFiles does not.

## Solution
Create `isTypeScriptSourceFile(name: string, options?: { excludeIndex?: boolean }): boolean` in utils/file.ts. Both findTypeScriptFiles and the resolver's walk can use it. The resolver would pass `excludeIndex: true`.