### PR TITLE
Extract playground filename constant in webapp [XXS]

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -1,5 +1,7 @@
 import { parse, collectTypes, collectFunctions, generateSolidity, generateSolidityFile, getErrorMessage } from "skittles";
 
+const PLAYGROUND_FILENAME = "playground.ts";
+
 export interface CompileResult {
   solidity: string;
   error: string | null;
@@ -12,12 +14,12 @@ export interface CompileResult {
 export function compileSource(source: string): CompileResult {
   try {
     // Collect shared types from the source (structs, enums, interfaces)
-    const { structs, enums, contractInterfaces } = collectTypes(source, "playground.ts");
-    const { functions, constants } = collectFunctions(source, "playground.ts");
+    const { structs, enums, contractInterfaces } = collectTypes(source, PLAYGROUND_FILENAME);
+    const { functions, constants } = collectFunctions(source, PLAYGROUND_FILENAME);
     const externalTypes = { structs, enums, contractInterfaces };
     const externalFunctions = { functions, constants };
 
-    const contracts = parse(source, "playground.ts", externalTypes, externalFunctions);
+    const contracts = parse(source, PLAYGROUND_FILENAME, externalTypes, externalFunctions);
     if (contracts.length === 0) {
       return { solidity: "", error: "No contract class found. Define a class to compile." };
     }


### PR DESCRIPTION
Closes #390

## Problem
`webapp/src/compiler.ts` uses the string `"playground.ts"` in three places (collectTypes, collectFunctions, parse). This is a magic string that could drift if ever changed.

## Solution
Add `const PLAYGROUND_FILENAME = "playground.ts"` at the top of compiler.ts and use it in all three calls.