### PR TITLE
Fix inconsistent cached file write for multi-contract files [M]

### DIFF
--- a/src/compiler/phases/generate.ts
+++ b/src/compiler/phases/generate.ts
@@ -96,6 +96,10 @@ export function generateOutput(
   for (const { filePath, relativePath, cached } of cachedFiles) {
     logInfo(`${relativePath} unchanged, using cache`);
     const cachedBaseName = baseName(filePath);
+    // For multi-contract files, all entries in cached.contracts share the same
+    // solidity (the combined output from generateSolidityFile), so we write
+    // the file once using [0]. The loop below iterates all contracts only to
+    // collect individual artifact entries and log each contract name.
     writeFile(
       path.join(outputDir, "solidity", `${cachedBaseName}.sol`),
       cached.contracts[0].solidity


### PR DESCRIPTION
Closes #402

## Problem
In `generateOutput`, when emitting cached files:
```ts
writeFile(path.join(outputDir, "solidity", `${cachedBaseName}.sol`), cached.contracts[0].solidity);
```
For a file with multiple contracts, `cached.contracts` contains one entry per contract, but each has the same `solidity` (the combined file from generateSolidityFile). So `contracts[0]` works. However, the loop then does:
```ts
for (const c of cached.contracts) {
  artifacts.push(...);
  logSuccess(...);
}
```
So we write the file once (correct) but iterate contracts for logging. The write happens before the loop. The structure is a bit confusing - we write once using [0] but iterate all. Consider adding a comment explaining that all entries share the same solidity for multi-contract files, or restructure for clarity.