### PR TITLE
Remove redundant ctx reset in collectTypes and collectFunctions [XS]

### DIFF
--- a/src/compiler/parser-context.ts
+++ b/src/compiler/parser-context.ts
@@ -80,3 +80,16 @@ export let ctx: ParserContext = createParserContext();
 export function resetContext(): void {
   ctx = createParserContext();
 }
+
+/**
+ * Reset per-run caches to avoid leaking state from prior parse() calls.
+ * Called at the start of collectTypes, collectFunctions, and parse.
+ */
+export function resetContextForParse(): void {
+  ctx.stateVarTypes = new Map();
+  ctx.currentVarTypes = new Map();
+  ctx.currentStringNames = new Set();
+  ctx.currentParamTypes = new Map();
+  ctx.currentEventNames = new Set();
+  ctx.destructureCounter = 0;
+}

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -26,7 +26,7 @@ import {
   propagateMutability,
 } from "./mutability.ts";
 import type { ParserContext } from "./parser-context.ts";
-import { ctx } from "./parser-context.ts";
+import { ctx, resetContextForParse } from "./parser-context.ts";
 import { getEnumMemberName } from "./parser-utils.ts";
 import { parseStatement } from "./statement-parser.ts";
 import { inferType, parseType, parseTypeLiteralFields } from "./type-parser.ts";
@@ -74,12 +74,7 @@ export function collectTypes(
     true
   );
 
-  // Reset per-run caches to avoid leaking state from prior parse() calls.
-  ctx.stateVarTypes = new Map();
-  ctx.currentVarTypes = new Map();
-  ctx.currentStringNames = new Set();
-  ctx.currentParamTypes = new Map();
-  ctx.currentEventNames = new Set();
+  resetContextForParse();
 
   const structs: Map<string, SkittlesParameter[]> = new Map();
   const enums: Map<string, string[]> = new Map();
@@ -148,13 +143,7 @@ export function parse(
 
   ctx.currentSourceFile = sourceFile;
   ctx.arrayMethodCounter = 0;
-  ctx.stateVarTypes = new Map();
-  ctx.destructureCounter = 0;
-  // Reset per-parse caches to avoid leaking state between parse() calls.
-  ctx.currentVarTypes = new Map();
-  ctx.currentStringNames = new Set();
-  ctx.currentParamTypes = new Map();
-  ctx.currentEventNames = new Set();
+  resetContextForParse();
   ctx.contractStateVarNames = new Map();
   ctx.contractParentNames = new Map();
   ctx.parentStateVarNames = new Set();
@@ -404,13 +393,7 @@ export function collectFunctions(
     true
   );
 
-  // Reset per-run caches to avoid leaking state from prior parse() calls.
-  ctx.stateVarTypes = new Map();
-  ctx.currentVarTypes = new Map();
-  ctx.currentStringNames = new Set();
-  ctx.currentParamTypes = new Map();
-  ctx.currentEventNames = new Set();
-  ctx.destructureCounter = 0;
+  resetContextForParse();
 
   const functions: SkittlesFunction[] = [];
   const constants: Map<string, Expression> = new Map();


### PR DESCRIPTION
Closes #396

## Problem
In `parser.ts`, both `collectTypes` and `collectFunctions` reset the same ctx fields:
- stateVarTypes, currentVarTypes, currentStringNames, currentParamTypes, currentEventNames
- collectFunctions also resets destructureCounter

The `parse()` function also resets these. When collectTypes/collectFunctions are called from preScanContracts (compiler) or from parse(), the ctx may already have been reset. The comments say "Reset per-run caches to avoid leaking state from prior parse() calls" but the reset could be centralized.

## Solution
Consider having a single `resetParserContext()` or `resetContextForParse()` that both collectTypes, collectFunctions, and parse call at the start. This ensures consistency and avoids forgetting to reset a field when adding new ctx state.