### PR TITLE
Extract error message utility to eliminate DRY violation [S]

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -2,14 +2,13 @@
  * Extract a human-readable error message from an unknown caught value.
  *
  * @param err - The caught error value (typically from a `catch` clause).
- * @param fallback - Optional fallback message when `err` is not an `Error` instance.
- *                   Defaults to `"Unknown error"`.
+ * @param fallback - Optional fallback message when `err` is not an `Error` instance
+ *                   and `err` is nullish. Defaults to `"Unknown error occurred"`.
  * @returns The error message string.
  */
 export function getErrorMessage(
   err: unknown,
-  fallback: string = "Unknown error"
+  fallback = "Unknown error occurred"
 ): string {
-  if (err instanceof Error) return err.message;
-  return fallback;
+  return err instanceof Error ? err.message : String(err ?? fallback);
 }

--- a/test/utils/error.test.ts
+++ b/test/utils/error.test.ts
@@ -9,18 +9,27 @@ describe("getErrorMessage", () => {
     );
   });
 
-  it("returns the default fallback for non-Error values", () => {
-    expect(getErrorMessage("string error")).toBe("Unknown error");
-    expect(getErrorMessage(42)).toBe("Unknown error");
-    expect(getErrorMessage(null)).toBe("Unknown error");
-    expect(getErrorMessage(undefined)).toBe("Unknown error");
+  it("returns the default fallback for null and undefined", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error occurred");
+    expect(getErrorMessage(undefined)).toBe("Unknown error occurred");
   });
 
-  it("returns a custom fallback when provided", () => {
-    expect(getErrorMessage("oops", "Custom fallback")).toBe("Custom fallback");
+  it("stringifies non-Error, non-nullish values", () => {
+    expect(getErrorMessage("string error")).toBe("string error");
+    expect(getErrorMessage(42)).toBe("42");
+  });
+
+  it("returns a custom fallback for nullish values when provided", () => {
     expect(getErrorMessage(null, "Something went wrong")).toBe(
       "Something went wrong"
     );
+    expect(getErrorMessage(undefined, "Custom fallback")).toBe(
+      "Custom fallback"
+    );
+  });
+
+  it("stringifies non-Error values even when a custom fallback is provided", () => {
+    expect(getErrorMessage("oops", "Custom fallback")).toBe("oops");
   });
 
   it("uses Error.message even when a custom fallback is provided", () => {


### PR DESCRIPTION
Closes #385

## Problem
The pattern `err instanceof Error ? err.message : "Unknown error..."` appears in 10+ places across the codebase with slight variations:
- `Unknown error occurred` (index.ts, clean.ts, compile.ts, compiler.ts)
- `Unknown error` (config.ts, init.ts)
- `Unknown compilation error` (webapp compiler.ts)
- `String(err)` (compiler.ts pre-scan, solc.ts)

## Solution
Create a utility in `src/utils/error.ts`:
```ts
export function getErrorMessage(err: unknown, fallback = "Unknown error occurred"): string {
  return err instanceof Error ? err.message : String(err ?? fallback);
}
```
Then replace all occurrences with calls to this utility.

## Files to update
- src/index.ts
- src/config/config.ts
- src/commands/clean.ts
- src/commands/compile.ts
- src/commands/init.ts
- src/compiler/compiler.ts
- src/compiler/solc.ts
- webapp/src/compiler.ts