### PR TITLE
Improve empty catch blocks with explicit comments [XXS]

### DIFF
--- a/src/compiler/phases/cache.ts
+++ b/src/compiler/phases/cache.ts
@@ -46,8 +46,8 @@ export function loadCache(outputDir: string): CompilationCache {
       )
         return data;
     }
-  } catch (_ignored) {
-    // Corrupt cache, start fresh
+  } catch (_err) {
+    // Intentionally ignored – corrupt cache, start fresh
   }
   return {
     version: CACHE_VERSION,
@@ -68,8 +68,8 @@ export function saveCache(outputDir: string, cache: CompilationCache): void {
 export function updateCache(cacheDir: string, newCache: CompilationCache): void {
   try {
     saveCache(cacheDir, newCache);
-  } catch (_ignored) {
-    // Non critical if cache save fails
+  } catch (_err) {
+    // Intentionally ignored – non-critical if cache save fails
   }
 }
 


### PR DESCRIPTION
Closes #401

## Problem
`src/compiler/compiler.ts` has empty catch blocks:
- `loadCache`: `catch { /* Corrupt cache, start fresh */ }`
- `updateCache`: `catch { /* Non critical if cache save fails */ }`

These are intentional (swallow errors) but could be clearer. Some linters flag empty catches.

## Solution
Add explicit `// intentionally ignored` or keep the comment but ensure the catch variable is used if needed for logging in development. Alternatively use `catch (_err)` to satisfy linters that require catch to bind the error.