### PR TITLE
Consider using walkStatements for collectLocalVarNames in codegen [M]

### DIFF
--- a/src/compiler/codegen/rename.ts
+++ b/src/compiler/codegen/rename.ts
@@ -1,4 +1,5 @@
 import type { Expression, Statement } from "../../types/index.ts";
+import { walkStatements } from "../walker.ts";
 
 // ============================================================
 // Shadowed local variable renaming
@@ -6,39 +7,21 @@ import type { Expression, Statement } from "../../types/index.ts";
 
 export function collectLocalVarNames(stmts: Statement[]): Set<string> {
   const names = new Set<string>();
-  for (const s of stmts) {
-    switch (s.kind) {
-      case "variable-declaration":
-        names.add(s.name);
-        break;
-      case "tuple-destructuring":
-        for (const n of s.names) if (n !== null) names.add(n);
-        break;
-      case "if":
-        for (const n of collectLocalVarNames(s.thenBody)) names.add(n);
-        if (s.elseBody)
-          for (const n of collectLocalVarNames(s.elseBody)) names.add(n);
-        break;
-      case "for":
-        if (s.initializer?.kind === "variable-declaration")
-          names.add(s.initializer.name);
-        for (const n of collectLocalVarNames(s.body)) names.add(n);
-        break;
-      case "while":
-      case "do-while":
-        for (const n of collectLocalVarNames(s.body)) names.add(n);
-        break;
-      case "switch":
-        for (const c of s.cases)
-          for (const n of collectLocalVarNames(c.body)) names.add(n);
-        break;
-      case "try-catch":
-        if (s.returnVarName) names.add(s.returnVarName);
-        for (const n of collectLocalVarNames(s.successBody)) names.add(n);
-        for (const n of collectLocalVarNames(s.catchBody)) names.add(n);
-        break;
-    }
-  }
+  walkStatements(stmts, {
+    visitStatement(stmt) {
+      switch (stmt.kind) {
+        case "variable-declaration":
+          names.add(stmt.name);
+          break;
+        case "tuple-destructuring":
+          for (const n of stmt.names) if (n !== null) names.add(n);
+          break;
+        case "try-catch":
+          if (stmt.returnVarName) names.add(stmt.returnVarName);
+          break;
+      }
+    },
+  });
   return names;
 }
 


### PR DESCRIPTION
Closes #397

## Problem
`src/compiler/codegen.ts` has `collectLocalVarNames(stmts)` which manually switches on statement kinds and recurses into bodies (if, for, while, switch, try-catch, etc.). The `walker.ts` `walkStatements` does similar traversal with a visitor pattern.

`collectLocalVarNames` could be implemented using `walkStatements` with a visitor that collects variable-declaration names, tuple-destructuring names, etc. This would reduce duplication of the "how to recurse into compound statements" logic.

## Solution
Refactor `collectLocalVarNames` to use `walkStatements` with a custom visitor that accumulates names from variable-declaration, tuple-destructuring, for initializer, and try-catch returnVarName. The switch structure in walkStatements already encodes the recursion; we just need to extract the names we care about.