### PR TITLE
Constants import path inconsistency (webapp vs docs) [XXS]

### DIFF
--- a/docs/constants.ts
+++ b/docs/constants.ts
@@ -1,1 +1,1 @@
-export { URLS } from "../constants/urls";
+export { URLS } from "../constants/urls.ts";


### PR DESCRIPTION
Closes #429

The URL constants are re-exported differently:

- `webapp/src/constants.ts`: `export { URLS } from "../../constants/urls.ts";` (includes `.ts` extension)
- `docs/constants.ts`: `export { URLS } from "../constants/urls";` (no extension)

Both work with TypeScript resolution, but the inconsistency can cause confusion. **Recommendation:** Use the same style in both (either with or without `.ts`). The codebase generally uses `.ts` in imports (e.g. `from "./parser.ts"`), so consider adding `.ts` to docs/constants.ts for consistency.