### PR TITLE
Extend format script to webapp and docs [XS]

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/ test/",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"webapp/**/*.{ts,tsx}\" \"docs/**/*.{ts,tsx}\"",
     "prepublishOnly": "npm run build && npm test"
   },
   "repository": {


### PR DESCRIPTION
Closes #430

The `format` script in package.json only runs Prettier on `src/` and `test/`:

```json
"format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\""
```

The `webapp/` and `docs/` directories contain TypeScript/TSX/JS that would benefit from consistent formatting.

**Recommendation:** Extend the format script to include `webapp/**/*.{ts,tsx}` and `docs/**/*.{ts,tsx}` (or whatever patterns are appropriate for those projects). Ensure the root `.prettierrc` applies, or that subprojects have compatible config.