### PR TITLE
Replace webapp README with Skittles-specific content [S]

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,73 +1,28 @@
-# React + TypeScript + Vite
+# Skittles Webapp
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The Skittles webapp is the marketing site and interactive playground hosted at [skittles.dev](https://skittles.dev/). It includes a landing page that explains Skittles and a browser-based playground where users can write TypeScript smart contracts and see the compiled Solidity output in real time.
 
-Currently, two official plugins are available:
+## Running Locally
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+From the `webapp/` directory:
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+This starts the Vite dev server with hot module replacement.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## How It Works
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+The webapp imports the core Skittles package (`skittles`) directly to power the playground compiler. When a user types TypeScript in the playground editor, the source is passed through the Skittles parser and code generator entirely in the browser to produce Solidity output.
+
+The landing page includes a marketing overview, code comparison examples, feature highlights, and a quick-start guide.
+
+## Building
+
+```bash
+npm run build
 ```
+
+This compiles TypeScript and builds the production bundle into `dist/`.


### PR DESCRIPTION
Closes #421

The `webapp/README.md` is still the default Vite React template. It describes generic React + Vite setup, Babel/SWC plugins, and ESLint configuration, but does not describe the Skittles webapp or playground.

**Recommendation:** Replace with content that explains:
- What the webapp is (marketing site + playground)
- How to run it (`npm run dev` from webapp, or from root)
- How it integrates with the main Skittles package
- Any build/deploy notes if relevant