### PR TITLE
Stdlib resolver: make import path regex more robust [S]

### DIFF
--- a/src/stdlib/resolver.ts
+++ b/src/stdlib/resolver.ts
@@ -89,8 +89,18 @@ export function resolveStdlibFiles(referencedClasses: Set<string>): string[] {
     for (const match of source.matchAll(/from\s+["'](\.[^"']+)["']/g)) {
       const importPath = match[1];
       const resolved = path.resolve(path.dirname(entry.filePath), importPath);
-      if (resolved.startsWith(STDLIB_CONTRACTS_DIR) && !needed.has(resolved)) {
-        needed.add(resolved);
+      // Try the literal resolved path first, then fall back to appending .ts
+      // for extensionless imports (e.g. `from "./ERC20"` → `./ERC20.ts`).
+      const candidates = [resolved, resolved + ".ts"];
+      for (const candidate of candidates) {
+        if (
+          candidate.startsWith(STDLIB_CONTRACTS_DIR) &&
+          !needed.has(candidate) &&
+          fs.existsSync(candidate)
+        ) {
+          needed.add(candidate);
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #424

In `src/stdlib/resolver.ts` line 89, relative imports are resolved via:

```ts
for (const match of source.matchAll(/from\s+["'](\.[^"']+)["']/g))
```

The regex captures paths like `./ERC20.ts` and `./token/ERC20.ts`. Path resolution uses `path.resolve(path.dirname(entry.filePath), importPath)` but does not add `.ts` when the import omits the extension. Stdlib imports currently include `.ts`, so this works, but it is brittle if imports change to extensionless form.

**Recommendation:** Add explicit handling for extensionless imports (e.g. try `importPath` and `importPath + ".ts"` when resolving), or document the requirement that stdlib imports must include `.ts`.