### PR TITLE
Normalize import style: add space after comma in imports [XS]

### DIFF
--- a/src/compiler/expression-parser.ts
+++ b/src/compiler/expression-parser.ts
@@ -50,7 +50,7 @@ import {
   wrapStringTruthiness,
 } from "./parser-utils.ts";
 import { parseStatement, parseStatements } from "./statement-parser.ts";
-import { inferType,parseType } from "./type-parser.ts";
+import { inferType, parseType } from "./type-parser.ts";
 
 export function parseExpression(node: ts.Expression): Expression {
   if (ts.isNumericLiteral(node)) {

--- a/src/compiler/mutability.ts
+++ b/src/compiler/mutability.ts
@@ -15,7 +15,7 @@ import { ctx } from "./parser-context.ts";
 import { inferType } from "./type-parser.ts";
 import { walkStatements as walkStatementsShared } from "./walker.ts";
 export type { ASTVisitor } from "./walker.ts";
-export { walkExpression,walkStatements } from "./walker.ts";
+export { walkExpression, walkStatements } from "./walker.ts";
 
 /**
  * Propagate state mutability across call chains.

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -36,7 +36,7 @@ export { parseExpression } from "./expression-parser.ts";
 export { inferStateMutability } from "./mutability.ts";
 export type { ParserContext } from "./parser-context.ts";
 export { parseStatement } from "./statement-parser.ts";
-export { inferType,parseType } from "./type-parser.ts";
+export { inferType, parseType } from "./type-parser.ts";
 
 /**
  * Scan a source file for struct (type alias with type literal) and enum declarations,

--- a/src/compiler/phases/generate.ts
+++ b/src/compiler/phases/generate.ts
@@ -8,7 +8,7 @@ import type {
   SkittlesContractInterface,
   Statement,
 } from "../../types/index.ts";
-import { logError,logInfo, logSuccess } from "../../utils/console.ts";
+import { logError, logInfo, logSuccess } from "../../utils/console.ts";
 import { getErrorMessage } from "../../utils/error.ts";
 import { writeFile } from "../../utils/file.ts";
 import {

--- a/src/compiler/phases/parse-phase.ts
+++ b/src/compiler/phases/parse-phase.ts
@@ -8,12 +8,12 @@ import type {
   SkittlesFunction,
   SkittlesParameter,
 } from "../../types/index.ts";
-import { logError,logInfo } from "../../utils/console.ts";
+import { logError, logInfo } from "../../utils/console.ts";
 import { getErrorMessage } from "../../utils/error.ts";
 import { readFile } from "../../utils/file.ts";
 import { parse } from "../parser.ts";
 import type { CacheEntry, CompilationCache } from "./cache.ts";
-import { baseName,hashString } from "./cache.ts";
+import { baseName, hashString } from "./cache.ts";
 
 export interface ParsedFile {
   filePath: string;

--- a/src/compiler/phases/resolve-order.ts
+++ b/src/compiler/phases/resolve-order.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../types/index.ts";
 import { readFile } from "../../utils/file.ts";
 import { findExtendsReferences } from "../../utils/regex.ts";
-import { baseName,hashString } from "./cache.ts";
+import { baseName, hashString } from "./cache.ts";
 import type { PreScanState } from "./prescan.ts";
 
 /**

--- a/src/compiler/solc.ts
+++ b/src/compiler/solc.ts
@@ -1,6 +1,6 @@
 import solc from "solc";
 
-import type { AbiItem,SkittlesConfig } from "../types/index.ts";
+import type { AbiItem, SkittlesConfig } from "../types/index.ts";
 import { getErrorMessage } from "../utils/error.ts";
 import { BATCH_SOURCE_FILENAME } from "./constants.ts";
 

--- a/src/compiler/walker.ts
+++ b/src/compiler/walker.ts
@@ -1,4 +1,4 @@
-import type { Expression,Statement } from "../types/index.ts";
+import type { Expression, Statement } from "../types/index.ts";
 
 /**
  * Visitor interface for walking AST nodes. Both callbacks are optional;


### PR DESCRIPTION
Closes #417

Several import statements omit a space after the comma, which is inconsistent with typical style guides (Prettier, ESLint).

**Files affected:**
- `src/compiler/phases/generate.ts` line 11: `logError,logInfo, logSuccess` (also inconsistent: first two no space, third has space)
- `src/compiler/phases/parse-phase.ts` lines 11, 16: `logError,logInfo`, `baseName,hashString`
- `src/compiler/phases/resolve-order.ts` line 10: `baseName,hashString`
- `src/compiler/expression-parser.ts` line 53: `inferType,parseType`
- `src/compiler/parser.ts` line 39: `inferType,parseType`
- `src/compiler/solc.ts` line 3: `AbiItem,SkittlesConfig`
- `src/compiler/walker.ts` line 1: `Expression,Statement`
- `src/compiler/mutability.ts` line 18: `walkExpression,walkStatements`

**Recommendation:** Add a space after each comma in multi-import lines. Consider adding an ESLint rule (e.g. `comma-spacing`) to enforce this going forward.