### PR TITLE
Introduce path helper utilities for common patterns [M]

### DIFF
--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,15 +1,17 @@
-import path from "path";
-
 import { loadConfig } from "../config/config.ts";
 import { logError, logInfo, logSuccess } from "../utils/console.ts";
 import { getErrorMessage } from "../utils/error.ts";
 import { removeDirectory } from "../utils/file.ts";
+import {
+  cacheDir as resolveCacheDir,
+  outputDir as resolveOutputDir,
+} from "../utils/paths.ts";
 
 export async function cleanCommand(projectRoot: string): Promise<void> {
   try {
     const config = await loadConfig(projectRoot);
-    const outputDir = path.join(projectRoot, config.outputDir);
-    const cacheDir = path.join(projectRoot, config.cacheDir);
+    const outputDir = resolveOutputDir(projectRoot, config);
+    const cacheDir = resolveCacheDir(projectRoot, config);
     logInfo(`Removing output directory: ${config.outputDir}/`);
     removeDirectory(outputDir);
     logInfo(`Removing cache directory: ${config.cacheDir}/`);

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import ora from "ora";
-import path from "path";
 
 import { compile } from "../compiler/compiler.ts";
 import { loadConfig } from "../config/config.ts";
+import { DEBOUNCE_MS } from "../constants/debounce.ts";
 import { logError, logInfo, logSuccess } from "../utils/console.ts";
 import { getErrorMessage } from "../utils/error.ts";
-import { DEBOUNCE_MS } from "../constants/debounce.ts";
+import { contractsDir as resolveContractsDir } from "../utils/paths.ts";
 
 async function executeCompilation(
   projectRoot: string,
@@ -63,7 +63,7 @@ export async function compileCommand(projectRoot: string): Promise<void> {
 
 export async function watchCompile(projectRoot: string): Promise<() => void> {
   const config = await loadConfig(projectRoot);
-  const contractsDir = path.join(projectRoot, config.contractsDir);
+  const contractsDir = resolveContractsDir(projectRoot, config);
 
   // Run initial compilation
   await executeCompilation(projectRoot);

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,7 +1,10 @@
-import path from "path";
-
 import type { BuildArtifact, SkittlesConfig } from "../types/index.ts";
 import { logInfo } from "../utils/console.ts";
+import {
+  cacheDir as resolveCacheDir,
+  contractsDir as resolveContractsDir,
+  outputDir as resolveOutputDir,
+} from "../utils/paths.ts";
 import { analyzeContracts } from "./phases/analyze.ts";
 import { createNewCache, loadCache, updateCache } from "./phases/cache.ts";
 import { discoverFiles } from "./phases/discover.ts";
@@ -29,9 +32,9 @@ export async function compile(
   projectRoot: string,
   config: Required<SkittlesConfig>
 ): Promise<CompilationResult> {
-  const contractsDir = path.join(projectRoot, config.contractsDir);
-  const outputDir = path.join(projectRoot, config.outputDir);
-  const cacheDir = path.join(projectRoot, config.cacheDir);
+  const contractsDir = resolveContractsDir(projectRoot, config);
+  const outputDir = resolveOutputDir(projectRoot, config);
+  const cacheDir = resolveCacheDir(projectRoot, config);
 
   const artifacts: BuildArtifact[] = [];
   const errors: string[] = [];

--- a/src/compiler/phases/cache.ts
+++ b/src/compiler/phases/cache.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 
 import { getPackageVersion } from "../../utils/package.ts";
+import { cachePath } from "../../utils/paths.ts";
 import { CACHE_HASH_LENGTH, CACHE_VERSION } from "../constants.ts";
 
 const PACKAGE_VERSION: string = getPackageVersion();
@@ -36,10 +37,10 @@ export function baseName(filePath: string): string {
 }
 
 export function loadCache(outputDir: string): CompilationCache {
-  const cachePath = path.join(outputDir, ".skittles-cache.json");
+  const cacheFile = cachePath(outputDir);
   try {
-    if (fs.existsSync(cachePath)) {
-      const data = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+    if (fs.existsSync(cacheFile)) {
+      const data = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
       if (
         data.version === CACHE_VERSION &&
         data.skittlesVersion === PACKAGE_VERSION
@@ -57,9 +58,9 @@ export function loadCache(outputDir: string): CompilationCache {
 }
 
 export function saveCache(outputDir: string, cache: CompilationCache): void {
-  const cachePath = path.join(outputDir, ".skittles-cache.json");
+  const cacheFile = cachePath(outputDir);
   fs.mkdirSync(outputDir, { recursive: true });
-  fs.writeFileSync(cachePath, JSON.stringify(cache), "utf-8");
+  fs.writeFileSync(cacheFile, JSON.stringify(cache), "utf-8");
 }
 
 /**

--- a/src/compiler/phases/generate.ts
+++ b/src/compiler/phases/generate.ts
@@ -1,5 +1,3 @@
-import path from "path";
-
 import { DEFAULT_CONFIG } from "../../config/defaults.ts";
 import type {
   BuildArtifact,
@@ -11,6 +9,7 @@ import type {
 import { logError, logInfo, logSuccess } from "../../utils/console.ts";
 import { getErrorMessage } from "../../utils/error.ts";
 import { writeFile } from "../../utils/file.ts";
+import { solidityOutputPath } from "../../utils/paths.ts";
 import {
   buildSourceMap,
   generateSolidity,
@@ -101,7 +100,7 @@ export function generateOutput(
     // the file once using [0]. The loop below iterates all contracts only to
     // collect individual artifact entries and log each contract name.
     writeFile(
-      path.join(outputDir, "solidity", `${cachedBaseName}.sol`),
+      solidityOutputPath(outputDir, `${cachedBaseName}.sol`),
       cached.contracts[0].solidity
     );
     for (const c of cached.contracts) {
@@ -225,7 +224,7 @@ export function generateOutput(
       // Build source map linking generated Solidity lines to TypeScript source
       const sourceMap = buildSourceMap(solidity, contracts, relativePath);
       writeFile(
-        path.join(outputDir, "solidity", `${base}.sol.map`),
+        solidityOutputPath(outputDir, `${base}.sol.map`),
         JSON.stringify(sourceMap, null, 2)
       );
 
@@ -248,7 +247,7 @@ export function generateOutput(
         contractFunctions: contractFns,
         contractInherits: contractInheritsMap,
       };
-      writeFile(path.join(outputDir, "solidity", `${base}.sol`), solidity);
+      writeFile(solidityOutputPath(outputDir, `${base}.sol`), solidity);
 
       for (const contract of contracts) {
         artifacts.push({ contractName: contract.name, solidity, sourceMap });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,47 @@
+import path from "path";
+
+import type { SkittlesConfig } from "../types/index.ts";
+
+/**
+ * Resolve the absolute path to the contracts source directory.
+ */
+export function contractsDir(
+  projectRoot: string,
+  config: Pick<Required<SkittlesConfig>, "contractsDir">
+): string {
+  return path.join(projectRoot, config.contractsDir);
+}
+
+/**
+ * Resolve the absolute path to the build output directory.
+ */
+export function outputDir(
+  projectRoot: string,
+  config: Pick<Required<SkittlesConfig>, "outputDir">
+): string {
+  return path.join(projectRoot, config.outputDir);
+}
+
+/**
+ * Resolve the absolute path to the incremental build cache directory.
+ */
+export function cacheDir(
+  projectRoot: string,
+  config: Pick<Required<SkittlesConfig>, "cacheDir">
+): string {
+  return path.join(projectRoot, config.cacheDir);
+}
+
+/**
+ * Resolve the absolute path to a generated Solidity output file.
+ */
+export function solidityOutputPath(outputDir: string, baseName: string): string {
+  return path.join(outputDir, "solidity", baseName);
+}
+
+/**
+ * Resolve the absolute path to the compilation cache JSON file.
+ */
+export function cachePath(outputDir: string): string {
+  return path.join(outputDir, ".skittles-cache.json");
+}

--- a/test/utils/paths.test.ts
+++ b/test/utils/paths.test.ts
@@ -1,0 +1,69 @@
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import {
+  cacheDir,
+  cachePath,
+  contractsDir,
+  outputDir,
+  solidityOutputPath,
+} from "../../src/utils/paths";
+
+describe("contractsDir", () => {
+  it("should join projectRoot with config.contractsDir", () => {
+    const result = contractsDir("/project", { contractsDir: "contracts" });
+    expect(result).toBe(path.join("/project", "contracts"));
+  });
+
+  it("should handle custom contractsDir values", () => {
+    const result = contractsDir("/project", { contractsDir: "src/contracts" });
+    expect(result).toBe(path.join("/project", "src/contracts"));
+  });
+});
+
+describe("outputDir", () => {
+  it("should join projectRoot with config.outputDir", () => {
+    const result = outputDir("/project", { outputDir: "artifacts" });
+    expect(result).toBe(path.join("/project", "artifacts"));
+  });
+
+  it("should handle custom outputDir values", () => {
+    const result = outputDir("/project", { outputDir: "build/output" });
+    expect(result).toBe(path.join("/project", "build/output"));
+  });
+});
+
+describe("cacheDir", () => {
+  it("should join projectRoot with config.cacheDir", () => {
+    const result = cacheDir("/project", { cacheDir: "cache" });
+    expect(result).toBe(path.join("/project", "cache"));
+  });
+
+  it("should handle custom cacheDir values", () => {
+    const result = cacheDir("/project", { cacheDir: ".cache" });
+    expect(result).toBe(path.join("/project", ".cache"));
+  });
+});
+
+describe("solidityOutputPath", () => {
+  it("should join outputDir with solidity subdirectory and filename", () => {
+    const result = solidityOutputPath("/project/artifacts", "Token.sol");
+    expect(result).toBe(
+      path.join("/project/artifacts", "solidity", "Token.sol")
+    );
+  });
+
+  it("should handle source map filenames", () => {
+    const result = solidityOutputPath("/project/artifacts", "Token.sol.map");
+    expect(result).toBe(
+      path.join("/project/artifacts", "solidity", "Token.sol.map")
+    );
+  });
+});
+
+describe("cachePath", () => {
+  it("should join outputDir with .skittles-cache.json", () => {
+    const result = cachePath("/project/cache");
+    expect(result).toBe(path.join("/project/cache", ".skittles-cache.json"));
+  });
+});


### PR DESCRIPTION
Closes #423

Path construction is repeated in many places without a shared abstraction:

- `path.join(projectRoot, config.contractsDir)` in compiler.ts, compile.ts
- `path.join(projectRoot, config.outputDir)` in compiler.ts, clean.ts, cache.ts
- `path.join(projectRoot, config.cacheDir)` in compiler.ts, clean.ts
- `path.join(outputDir, "solidity", filename)` in generate.ts (multiple times)
- `path.join(projectRoot, ".skittles-cache.json")` in cache.ts

**Recommendation:** Add helpers in `src/utils/paths.ts` (or extend `src/utils/file.ts`) such as:
- `contractsDir(projectRoot, config)`
- `outputDir(projectRoot, config)`
- `solidityOutputPath(outputDir, baseName)`
- `cachePath(outputDir)`

This reduces duplication and centralizes path logic for easier config changes.