### PR TITLE
DRY: Extract generateSolidity branching helper [S]

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -188,6 +188,23 @@ export function generateSolidity(
   return generateSolidityFile([contract], imports, solidityConfig);
 }
 
+/**
+ * Generate Solidity source for one or more contracts, encapsulating the
+ * common branching between `generateSolidityFile` (multiple contracts)
+ * and `generateSolidity` (single contract).  Returns an empty string
+ * when the contracts array is empty.
+ */
+export function generateSolidityForContracts(
+  contracts: SkittlesContract[],
+  imports?: string[],
+  solidityConfig?: SolidityConfig
+): string {
+  if (contracts.length === 0) return "";
+  return contracts.length > 1
+    ? generateSolidityFile(contracts, imports, solidityConfig)
+    : generateSolidity(contracts[0], imports, solidityConfig);
+}
+
 // ============================================================
 // Contract body generation
 // ============================================================

--- a/src/compiler/phases/generate.ts
+++ b/src/compiler/phases/generate.ts
@@ -12,8 +12,7 @@ import { writeFile } from "../../utils/file.ts";
 import { solidityOutputPath } from "../../utils/paths.ts";
 import {
   buildSourceMap,
-  generateSolidity,
-  generateSolidityFile,
+  generateSolidityForContracts,
 } from "../codegen.ts";
 import { formatSolidity } from "../formatter.ts";
 import { filterStatements } from "../walker.ts";
@@ -206,12 +205,7 @@ export function generateOutput(
         }
       }
 
-      const rawSolidity =
-        contracts.length > 1
-          ? generateSolidityFile(contracts, uniqueImports, config.solidity)
-          : contracts.length === 1
-            ? generateSolidity(contracts[0], uniqueImports, config.solidity)
-            : "";
+      const rawSolidity = generateSolidityForContracts(contracts, uniqueImports, config.solidity);
 
       if (!rawSolidity) continue;
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -64,7 +64,7 @@ export type Indexed<T> = T;
 export type View<T> = T;
 
 // Compiler API (parser + codegen)
-export { generateSolidity, generateSolidityFile } from "./compiler/codegen.ts";
+export { generateSolidity, generateSolidityFile, generateSolidityForContracts } from "./compiler/codegen.ts";
 export {
   collectClassNames,
   collectFunctions,

--- a/test/behavioral/helpers.ts
+++ b/test/behavioral/helpers.ts
@@ -1,8 +1,7 @@
 import { ethers } from "ethers";
 
 import {
-  generateSolidity,
-  generateSolidityFile,
+  generateSolidityForContracts,
 } from "../../src/compiler/codegen";
 import { parse } from "../../src/compiler/parser";
 import { compileSolidity } from "../../src/compiler/solc";
@@ -65,10 +64,7 @@ export async function compileAndDeploy(
     throw new Error("No contracts found in source");
   }
 
-  const solidity =
-    contracts.length > 1
-      ? generateSolidityFile(contracts)
-      : generateSolidity(contracts[0]);
+  const solidity = generateSolidityForContracts(contracts);
 
   const compiled = compileSolidity(contractName, solidity, defaultConfig);
   if (compiled.errors.length > 0) {

--- a/test/compiler/codegen.test.ts
+++ b/test/compiler/codegen.test.ts
@@ -4,6 +4,7 @@ import {
   generateExpression,
   generateSolidity,
   generateSolidityFile,
+  generateSolidityForContracts,
   generateStatement,
   generateType,
   resolveShadowedLocals,
@@ -1147,6 +1148,42 @@ describe("generateSolidity", () => {
     );
     expect(sol).toContain("interface IToken {");
     expect(sol).toContain("IToken internal token;");
+  });
+});
+
+// ============================================================
+// generateSolidityForContracts (branching helper)
+// ============================================================
+
+describe("generateSolidityForContracts", () => {
+  it("should return empty string for empty contracts array", () => {
+    const sol = generateSolidityForContracts([]);
+    expect(sol).toBe("");
+  });
+
+  it("should generate solidity for a single contract", () => {
+    const sol = generateSolidityForContracts([emptyContract()]);
+    expect(sol).toContain("pragma solidity ^0.8.20;");
+    expect(sol).toContain("contract Test {");
+  });
+
+  it("should generate solidity for multiple contracts", () => {
+    const parent = emptyContract({ name: "Base" });
+    const child = emptyContract({ name: "Child", inherits: ["Base"] });
+    const sol = generateSolidityForContracts([parent, child]);
+    expect(sol).toContain("contract Base {");
+    expect(sol).toContain("contract Child is Base {");
+  });
+
+  it("should forward imports and solidity config", () => {
+    const sol = generateSolidityForContracts(
+      [emptyContract()],
+      ["@openzeppelin/contracts/token/ERC20/ERC20.sol"],
+      { version: "^0.8.24", license: "GPL-3.0" }
+    );
+    expect(sol).toContain("pragma solidity ^0.8.24;");
+    expect(sol).toContain("SPDX-License-Identifier: GPL-3.0");
+    expect(sol).toContain('import "@openzeppelin/contracts/token/ERC20/ERC20.sol";');
   });
 });
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -1,4 +1,4 @@
-import { parse, collectTypes, collectFunctions, generateSolidity, generateSolidityFile, getErrorMessage } from "skittles";
+import { parse, collectTypes, collectFunctions, generateSolidityForContracts, getErrorMessage } from "skittles";
 
 const PLAYGROUND_FILENAME = "playground.ts";
 
@@ -24,10 +24,7 @@ export function compileSource(source: string): CompileResult {
       return { solidity: "", error: "No contract class found. Define a class to compile." };
     }
 
-    const solidity =
-      contracts.length > 1
-        ? generateSolidityFile(contracts)
-        : generateSolidity(contracts[0]);
+    const solidity = generateSolidityForContracts(contracts);
 
     return { solidity, error: null };
   } catch (err) {


### PR DESCRIPTION
Closes #420

The pattern `contracts.length > 1 ? generateSolidityFile(contracts) : generateSolidity(contracts[0])` appears in three places:

- `webapp/src/compiler.ts` lines 27–30
- `test/behavioral/helpers.ts` lines 68–71
- `src/compiler/phases/generate.ts` lines 211–215 (slightly different: includes `uniqueImports` and `config.solidity`)

**Recommendation:** Add a helper in `src/compiler/codegen.ts` (or similar) such as `generateSolidityForContracts(contracts, options?)` that encapsulates this branching. The generate phase and public API can use it. Reduces duplication and ensures consistent behavior.