### PR TITLE
DRY: Extract shared compile pipeline (parse → generate) [M]

### DIFF
--- a/src/compiler/pipeline.ts
+++ b/src/compiler/pipeline.ts
@@ -1,0 +1,32 @@
+import type { SkittlesContract } from "../types/index.ts";
+import { generateSolidityForContracts } from "./codegen.ts";
+import { collectFunctions, collectTypes, parse } from "./parser.ts";
+
+export interface CompilePipelineResult {
+  contracts: SkittlesContract[];
+  solidity: string;
+}
+
+/**
+ * Shared compile pipeline: parse TypeScript source and generate Solidity.
+ *
+ * Internally calls collectTypes → collectFunctions → parse → generateSolidityForContracts.
+ * This is the single authoritative implementation of the parse→generate flow.
+ */
+export function compileToSolidity(
+  source: string,
+  filePath: string
+): CompilePipelineResult {
+  const { structs, enums, contractInterfaces } = collectTypes(
+    source,
+    filePath
+  );
+  const { functions, constants } = collectFunctions(source, filePath);
+  const externalTypes = { structs, enums, contractInterfaces };
+  const externalFunctions = { functions, constants };
+
+  const contracts = parse(source, filePath, externalTypes, externalFunctions);
+  const solidity = generateSolidityForContracts(contracts);
+
+  return { contracts, solidity };
+}

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -71,6 +71,8 @@ export {
   collectTypes,
   parse,
 } from "./compiler/parser.ts";
+export { compileToSolidity } from "./compiler/pipeline.ts";
+export type { CompilePipelineResult } from "./compiler/pipeline.ts";
 
 // Utility functions
 export { getErrorMessage } from "./utils/error.ts";

--- a/test/behavioral/helpers.ts
+++ b/test/behavioral/helpers.ts
@@ -1,9 +1,6 @@
 import { ethers } from "ethers";
 
-import {
-  generateSolidityForContracts,
-} from "../../src/compiler/codegen";
-import { parse } from "../../src/compiler/parser";
+import { compileToSolidity } from "../../src/compiler/pipeline";
 import { compileSolidity } from "../../src/compiler/solc";
 import { defaultConfig } from "../fixtures";
 
@@ -59,12 +56,10 @@ export async function compileAndDeploy(
   contractName: string,
   constructorArgs: unknown[] = []
 ): Promise<DeployedContract> {
-  const contracts = parse(source, "test.ts");
+  const { contracts, solidity } = compileToSolidity(source, "test.ts");
   if (contracts.length === 0) {
     throw new Error("No contracts found in source");
   }
-
-  const solidity = generateSolidityForContracts(contracts);
 
   const compiled = compileSolidity(contractName, solidity, defaultConfig);
   if (compiled.errors.length > 0) {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -1,4 +1,4 @@
-import { parse, collectTypes, collectFunctions, generateSolidityForContracts, getErrorMessage } from "skittles";
+import { compileToSolidity, getErrorMessage } from "skittles";
 
 const PLAYGROUND_FILENAME = "playground.ts";
 
@@ -13,18 +13,10 @@ export interface CompileResult {
  */
 export function compileSource(source: string): CompileResult {
   try {
-    // Collect shared types from the source (structs, enums, interfaces)
-    const { structs, enums, contractInterfaces } = collectTypes(source, PLAYGROUND_FILENAME);
-    const { functions, constants } = collectFunctions(source, PLAYGROUND_FILENAME);
-    const externalTypes = { structs, enums, contractInterfaces };
-    const externalFunctions = { functions, constants };
-
-    const contracts = parse(source, PLAYGROUND_FILENAME, externalTypes, externalFunctions);
+    const { contracts, solidity } = compileToSolidity(source, PLAYGROUND_FILENAME);
     if (contracts.length === 0) {
       return { solidity: "", error: "No contract class found. Define a class to compile." };
     }
-
-    const solidity = generateSolidityForContracts(contracts);
 
     return { solidity, error: null };
   } catch (err) {


### PR DESCRIPTION
Closes #418

The parse → collectTypes/collectFunctions → generateSolidity flow is duplicated in two places:

1. **webapp/src/compiler.ts** – Uses `collectTypes`, `collectFunctions`, `parse`, then `generateSolidity`/`generateSolidityFile` based on contract count. Uses public `skittles` API.

2. **test/behavioral/helpers.ts** – `compileAndDeploy` calls `parse` directly (no collectTypes/collectFunctions for single-file contracts), then the same `generateSolidity`/`generateSolidityFile` branching. Imports from `../../src/compiler/*` directly.

**Recommendation:** Factor a shared helper (e.g. in `src/compiler/` or `src/exports.ts`) that accepts source + filePath and returns `{ contracts, solidity }`. The webapp and behavioral tests can both use it. For single-file contracts without shared types, `collectTypes`/`collectFunctions` can be called internally or skipped when not needed.